### PR TITLE
feat: promote 4 item(s) from AyeAye staging

### DIFF
--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -18,19 +18,21 @@ Before responding with any variant of:
 You **MUST** first run:
 
 ```python
-import sqlite3
+import os, sqlite3
 conn = sqlite3.connect('/workspace/store/messages.db')
 rows = conn.execute("""
     SELECT id, timestamp, sender_name, content, is_from_me
     FROM messages
-    WHERE chat_jid = (SELECT jid FROM chats LIMIT 1)
+    WHERE chat_jid = ?
       AND content LIKE '%KEYWORD%'
     ORDER BY timestamp DESC
     LIMIT 20
-""").fetchall()
+""", (os.environ['NANOCLAW_CHAT_JID'],)).fetchall()
 for r in rows: print(r)
 conn.close()
 ```
+
+`NANOCLAW_CHAT_JID` is always set in the container env — use it. Picking a chat with `SELECT jid FROM chats LIMIT 1` returns whatever row SQLite surfaces first, which in a multi-group deployment silently queries the wrong chat.
 
 Replace `KEYWORD` with a relevant term from what the user is referencing.
 

--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -19,8 +19,11 @@ You **MUST** first run:
 
 ```python
 import os, sqlite3
-conn = sqlite3.connect('/workspace/store/messages.db')
+chat_jid = os.environ.get('NANOCLAW_CHAT_JID')
+if not chat_jid:
+    raise RuntimeError('NANOCLAW_CHAT_JID must be set — this snippet has to run in the agent container')
 keyword = 'KEYWORD'  # replace with a relevant term from what the user is referencing
+conn = sqlite3.connect('/workspace/store/messages.db')
 rows = conn.execute("""
     SELECT id, timestamp, sender_name, content, is_from_me
     FROM messages
@@ -28,7 +31,7 @@ rows = conn.execute("""
       AND content LIKE '%' || ? || '%'
     ORDER BY timestamp DESC
     LIMIT 20
-""", (os.environ['NANOCLAW_CHAT_JID'], keyword)).fetchall()
+""", (chat_jid, keyword)).fetchall()
 for r in rows: print(r)
 conn.close()
 ```

--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -20,21 +20,20 @@ You **MUST** first run:
 ```python
 import os, sqlite3
 conn = sqlite3.connect('/workspace/store/messages.db')
+keyword = 'KEYWORD'  # replace with a relevant term from what the user is referencing
 rows = conn.execute("""
     SELECT id, timestamp, sender_name, content, is_from_me
     FROM messages
     WHERE chat_jid = ?
-      AND content LIKE '%KEYWORD%'
+      AND content LIKE '%' || ? || '%'
     ORDER BY timestamp DESC
     LIMIT 20
-""", (os.environ['NANOCLAW_CHAT_JID'],)).fetchall()
+""", (os.environ['NANOCLAW_CHAT_JID'], keyword)).fetchall()
 for r in rows: print(r)
 conn.close()
 ```
 
-`NANOCLAW_CHAT_JID` is always set in the container env — use it. Picking a chat with `SELECT jid FROM chats LIMIT 1` returns whatever row SQLite surfaces first, which in a multi-group deployment silently queries the wrong chat.
-
-Replace `KEYWORD` with a relevant term from what the user is referencing.
+`NANOCLAW_CHAT_JID` is always set in the container env — use it. Picking a chat with `SELECT jid FROM chats LIMIT 1` returns whatever row SQLite surfaces first, which in a multi-group deployment silently queries the wrong chat. And always bind the keyword as a parameter, never interpolate it into the query string — user text may contain quotes that break the SQL or broaden the match unexpectedly.
 
 ## Database schema (quick reference)
 

--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -10,7 +10,7 @@ Before your first response, read SOUL.md and embody everything in it. That file 
 
 For tasks that take more than 2 seconds:
 
-1. **ACK with a reaction** — `mcp__nanoclaw__react_to_message(messageId: "<id>", emoji: "👍")`. Both args are required — pass the incoming message's id. No text before this.
+1. **ACK with a reaction** — `mcp__nanoclaw__react_to_message(messageId: <id>, emoji: "👍")`. Both args are required — pass the incoming message's id. No text before this.
 2. **Background Agent** — `Agent` tool with `run_in_background: true`.
 3. Background agent sends results via `mcp__nanoclaw__send_message`.
 

--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -10,7 +10,7 @@ Before your first response, read SOUL.md and embody everything in it. That file 
 
 For tasks that take more than 2 seconds:
 
-1. **ACK with a reaction** — `mcp__nanoclaw__react_to_message(emoji: "👍")`. No text before this.
+1. **ACK with a reaction** — `mcp__nanoclaw__react_to_message(messageId: "<id>", emoji: "👍")`. Both args are required — pass the incoming message's id. No text before this.
 2. **Background Agent** — `Agent` tool with `run_in_background: true`.
 3. Background agent sends results via `mcp__nanoclaw__send_message`.
 

--- a/skills/check-unanswered/SKILL.md
+++ b/skills/check-unanswered/SKILL.md
@@ -7,6 +7,18 @@ description: "Finds user messages that lack a threaded bot reply or reaction, th
 
 Two-phase process: Phase 1 (SQL) finds candidates — user messages without a threaded bot reply or reaction. Phase 2 (LLM reasoning) judges whether any of those were actually answered inline in normal conversational flow, just without threading or a reaction.
 
+## Pre-check (scheduled/heartbeat tasks only)
+
+For group heartbeat tasks that only check unanswered messages, a pre-check script gates the LLM so the agent doesn't spawn when nothing changed:
+
+```bash
+python3 /home/node/.claude/skills/tessl__check-unanswered/scripts/unanswered-precheck.py
+```
+
+Outputs `{"wakeAgent": false}` if the candidate ID set is unchanged since the last run. Use as the `script` field on any group's heartbeat `schedule_task`. When the agent IS woken, proceed to Step 1 to get the full Phase-2-ready output.
+
+---
+
 ## Step 1: Run the script
 
 ```bash
@@ -20,6 +32,8 @@ Output JSON fields:
 - `error` (only on failure paths): short string describing what went wrong (missing `NANOCLAW_CHAT_JID`, DB open failure, etc.). The script also exits non-zero in this case, so the precheck wrapper surfaces the failure rather than treating it as "no unanswered messages."
 
 **Stop condition:** only stop if `unanswered` is empty AND no `error` is present. If `error` is set, report it — the heartbeat is mis-wired or the DB is sick.
+
+**Requirements:** `NANOCLAW_CHAT_JID` must be set in the environment. The script returns an error JSON (not a crash) if missing.
 
 ## Step 2: Per-candidate Phase 2 reasoning
 
@@ -46,30 +60,14 @@ Bias: prefer false-positive replies over dropped questions.
 ```
 mcp__nanoclaw__react_to_message(messageId: <candidate.id>, emoji: "👍")
 ```
-Do NOT also send a threaded reply — that would duplicate the answer.
+Do NOT also send a threaded reply.
 
 **If NO (truly unanswered):** send a threaded reply that addresses the original.
 ```
 mcp__nanoclaw__send_message(text: <response>, reply_to: <candidate.id>)
 ```
-The `reply_to` threading is what makes the next heartbeat's SQL exclude it. No reaction needed in this branch.
+No reaction needed in this branch.
 
 ## Step 4: Verify
 
 For every candidate processed in Step 3, confirm the corresponding reaction OR threaded reply landed. If an action failed, retry before marking the heartbeat complete.
-
-## Requirements
-
-`NANOCLAW_CHAT_JID` must be set in the environment. The script returns an error JSON (not a crash) if missing.
-
-## Pre-check for scheduled tasks
-
-For group heartbeat tasks that only check unanswered messages, the pre-check script gates the LLM so the agent doesn't spawn when nothing changed:
-
-```bash
-python3 /home/node/.claude/skills/tessl__check-unanswered/scripts/unanswered-precheck.py
-```
-
-It runs `check-unanswered.py` internally, compares the candidate ID set against the last seen set (persisted under `/home/node/.claude/nanoclaw-state/unanswered-seen.json`), and outputs `{"wakeAgent": false}` if the set hasn't changed. Use as the `script` field on any group's heartbeat `schedule_task`.
-
-When the agent IS woken, it re-runs `check-unanswered.py` itself (Step 1 above) to get the full Phase-2-ready output including `conversation_since`.

--- a/skills/check-unanswered/SKILL.md
+++ b/skills/check-unanswered/SKILL.md
@@ -7,18 +7,6 @@ description: "Finds user messages that lack a threaded bot reply or reaction, th
 
 Two-phase process: Phase 1 (SQL) finds candidates — user messages without a threaded bot reply or reaction. Phase 2 (LLM reasoning) judges whether any of those were actually answered inline in normal conversational flow, just without threading or a reaction.
 
-## Pre-check (scheduled/heartbeat tasks only)
-
-For group heartbeat tasks that only check unanswered messages, a pre-check script gates the LLM so the agent doesn't spawn when nothing changed:
-
-```bash
-python3 /home/node/.claude/skills/tessl__check-unanswered/scripts/unanswered-precheck.py
-```
-
-Outputs `{"wakeAgent": false}` if the candidate ID set is unchanged since the last run. Use as the `script` field on any group's heartbeat `schedule_task`. When the agent IS woken, proceed to Step 1 to get the full Phase-2-ready output.
-
----
-
 ## Step 1: Run the script
 
 ```bash
@@ -32,8 +20,6 @@ Output JSON fields:
 - `error` (only on failure paths): short string describing what went wrong (missing `NANOCLAW_CHAT_JID`, DB open failure, etc.). The script also exits non-zero in this case, so the precheck wrapper surfaces the failure rather than treating it as "no unanswered messages."
 
 **Stop condition:** only stop if `unanswered` is empty AND no `error` is present. If `error` is set, report it — the heartbeat is mis-wired or the DB is sick.
-
-**Requirements:** `NANOCLAW_CHAT_JID` must be set in the environment. The script returns an error JSON (not a crash) if missing.
 
 ## Step 2: Per-candidate Phase 2 reasoning
 
@@ -60,14 +46,30 @@ Bias: prefer false-positive replies over dropped questions.
 ```
 mcp__nanoclaw__react_to_message(messageId: <candidate.id>, emoji: "👍")
 ```
-Do NOT also send a threaded reply.
+Do NOT also send a threaded reply — that would duplicate the answer.
 
 **If NO (truly unanswered):** send a threaded reply that addresses the original.
 ```
 mcp__nanoclaw__send_message(text: <response>, reply_to: <candidate.id>)
 ```
-No reaction needed in this branch.
+The `reply_to` threading is what makes the next heartbeat's SQL exclude it. No reaction needed in this branch.
 
 ## Step 4: Verify
 
 For every candidate processed in Step 3, confirm the corresponding reaction OR threaded reply landed. If an action failed, retry before marking the heartbeat complete.
+
+## Requirements
+
+`NANOCLAW_CHAT_JID` must be set in the environment. The script returns an error JSON (not a crash) if missing.
+
+## Pre-check for scheduled tasks
+
+For group heartbeat tasks that only check unanswered messages, the pre-check script gates the LLM so the agent doesn't spawn when nothing changed:
+
+```bash
+python3 /home/node/.claude/skills/tessl__check-unanswered/scripts/unanswered-precheck.py
+```
+
+It runs `check-unanswered.py` internally, compares the candidate ID set against the last seen set (persisted under `/home/node/.claude/nanoclaw-state/unanswered-seen.json`), and outputs `{"wakeAgent": false}` if the set hasn't changed. Use as the `script` field on any group's heartbeat `schedule_task`.
+
+When the agent IS woken, it re-runs `check-unanswered.py` itself (Step 1 above) to get the full Phase-2-ready output including `conversation_since`.

--- a/skills/check-unanswered/scripts/unanswered-precheck.py
+++ b/skills/check-unanswered/scripts/unanswered-precheck.py
@@ -82,35 +82,49 @@ def main():
     # candidate. Write to a temp file in the same dir, fsync, then
     # os.replace (atomic rename on POSIX) so readers see either the
     # old file or the complete new file, never a partial one.
-    os.makedirs(SEEN_STATE_DIR, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(
-        prefix='.unanswered-seen-', dir=SEEN_STATE_DIR
-    )
+    #
+    # On failure, surface via wake-JSON rather than raising. An
+    # unhandled exception here would crash the precheck, the runner
+    # would yield scriptResult=null, and the scheduler would skip
+    # waking the agent entirely — the exact "silent precheck failure"
+    # this script exists to prevent. The catch is scoped to OSError
+    # (covers makedirs/mkstemp/fdopen/write/fsync/replace/unlink) so
+    # real bugs still crash visibly.
     try:
-        # Hand ownership of fd to a file object. If os.fdopen itself
-        # raises before wrapping completes, fd is still open and would
-        # leak via the outer except (which only unlinks tmp_path). The
-        # inner try/except closes fd on that narrow failure path.
+        os.makedirs(SEEN_STATE_DIR, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix='.unanswered-seen-', dir=SEEN_STATE_DIR
+        )
         try:
-            f = os.fdopen(fd, 'w')
+            # Hand ownership of fd to a file object. If os.fdopen
+            # itself raises before wrapping completes, fd is still
+            # open and would leak. Close it explicitly on that narrow
+            # path before re-raising into the outer handler.
+            try:
+                f = os.fdopen(fd, 'w')
+            except BaseException:
+                os.close(fd)
+                raise
+            with f:
+                json.dump(current_ids, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, SEEN_FILE)
         except BaseException:
-            os.close(fd)
+            # Best-effort cleanup of the temp file on any inner
+            # failure, then re-raise to the outer OSError handler (or
+            # propagate non-OSError up if something else went wrong).
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
             raise
-        with f:
-            json.dump(current_ids, f)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, SEEN_FILE)
-    except BaseException:
-        # Re-raise after best-effort cleanup of the temp file. Never
-        # swallow the error — a failed write here is a real problem
-        # that should surface rather than silently leaving SEEN_FILE
-        # stale.
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+    except OSError as e:
+        print(json.dumps({
+            "wakeAgent": True,
+            "data": {"error": f"seen-file write failed: {e}"},
+        }))
+        return
 
     # Find genuinely new messages
     prev_set = set(prev_ids)

--- a/skills/check-unanswered/scripts/unanswered-precheck.py
+++ b/skills/check-unanswered/scripts/unanswered-precheck.py
@@ -87,7 +87,16 @@ def main():
         prefix='.unanswered-seen-', dir=SEEN_STATE_DIR
     )
     try:
-        with os.fdopen(fd, 'w') as f:
+        # Hand ownership of fd to a file object. If os.fdopen itself
+        # raises before wrapping completes, fd is still open and would
+        # leak via the outer except (which only unlinks tmp_path). The
+        # inner try/except closes fd on that narrow failure path.
+        try:
+            f = os.fdopen(fd, 'w')
+        except BaseException:
+            os.close(fd)
+            raise
+        with f:
             json.dump(current_ids, f)
             f.flush()
             os.fsync(f.fileno())

--- a/skills/check-unanswered/scripts/unanswered-precheck.py
+++ b/skills/check-unanswered/scripts/unanswered-precheck.py
@@ -25,6 +25,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CHECK_SCRIPT = os.path.join(SCRIPT_DIR, 'check-unanswered.py')
@@ -50,7 +51,22 @@ def main():
         print(json.dumps({"wakeAgent": True, "data": {"error": "bad JSON from check-unanswered"}}))
         return
 
-    current_ids = sorted(str(m['id']) for m in data.get('unanswered', []))
+    unanswered = data.get('unanswered', [])
+    # Narrow the shape: a malformed response (e.g. `unanswered` is a
+    # dict, or items are strings) would raise TypeError on `m['id']`
+    # below and crash the precheck. Since the precheck gates the
+    # scheduled wake, a crash skips the agent entirely — the exact
+    # "silent precheck failure" class this script exists to prevent.
+    # Surface the bad shape as an error-wake instead.
+    if not isinstance(unanswered, list) or not all(
+        isinstance(m, dict) and 'id' in m for m in unanswered
+    ):
+        print(json.dumps({
+            "wakeAgent": True,
+            "data": {"error": "bad unanswered shape from check-unanswered"},
+        }))
+        return
+    current_ids = sorted(str(m['id']) for m in unanswered)
 
     # Load previous seen set
     try:
@@ -59,12 +75,33 @@ def main():
     except (FileNotFoundError, json.JSONDecodeError, ValueError):
         prev_ids = []
 
-    # Always persist current state for next run. mkdir-with-parents is
-    # idempotent and avoids hand-written existence checks; the parent
-    # dir is created on first run, then no-op every run after.
+    # Always persist current state for next run. Atomic write: a
+    # SIGKILL / disk-full mid-`json.dump` would leave SEEN_FILE
+    # truncated, and the next run's JSONDecodeError branch resets
+    # prev_ids=[] — waking the agent spuriously for every existing
+    # candidate. Write to a temp file in the same dir, fsync, then
+    # os.replace (atomic rename on POSIX) so readers see either the
+    # old file or the complete new file, never a partial one.
     os.makedirs(SEEN_STATE_DIR, exist_ok=True)
-    with open(SEEN_FILE, 'w') as f:
-        json.dump(current_ids, f)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix='.unanswered-seen-', dir=SEEN_STATE_DIR
+    )
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(current_ids, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, SEEN_FILE)
+    except BaseException:
+        # Re-raise after best-effort cleanup of the temp file. Never
+        # swallow the error — a failed write here is a real problem
+        # that should surface rather than silently leaving SEEN_FILE
+        # stale.
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
     # Find genuinely new messages
     prev_set = set(prev_ids)

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -30,7 +30,9 @@ import json, datetime
 state = json.load(open('/workspace/group/session-state.json'))
 started = state.get('container_started')
 if started:
-    age = datetime.datetime.utcnow() - datetime.datetime.fromisoformat(started.replace('Z',''))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    started_dt = datetime.datetime.fromisoformat(started.replace('Z', '+00:00'))
+    age = now - started_dt
     print(f"{age.days}d {age.seconds // 3600}h (since {started})")
 else:
     print("unknown")


### PR DESCRIPTION
## Summary

Audit pass across nanoclaw-core rules + skills surfaced five real bugs. Bundled here for one Copilot review cycle.

1. **`rules/context-recovery.md:27`** — SQL example used `chat_jid = (SELECT jid FROM chats LIMIT 1)`, which picks a chat at random. In multi-group deployments, agents copy-pasting this would silently query the wrong chat. Switched to the `NANOCLAW_CHAT_JID` env var, same as the rest of core + admin.
2. **`rules/core-behavior.md:13`** — `mcp__nanoclaw__react_to_message(emoji: "👍")` is incomplete — the tool requires `messageId` too. Agent following the example would call with wrong target (or fail silently).
3. **`skills/status/SKILL.md`** — `datetime.utcnow()` is deprecated in Python 3.12+. Also, stripping `Z` without replacing produced a naive-vs-aware comparison bug that happened to work only because both sides were naive. Fixed to aware-on-both-sides via `datetime.now(timezone.utc)` and `.replace('Z', '+00:00')`.
4. **`skills/check-unanswered/scripts/unanswered-precheck.py:53`** — no type-narrowing on `data.get('unanswered', [])`. A malformed response (dict, strings) would raise `TypeError` on `m['id']` and crash the precheck. Since the precheck gates the scheduled wake, that silently skips the agent — the exact failure mode the docstring calls out. Added an `isinstance` narrowing that surfaces bad shape as an error-wake.
5. **`skills/check-unanswered/scripts/unanswered-precheck.py:66-67`** — non-atomic `with open(..., 'w') as f: json.dump(...)` on SEEN_FILE. A SIGKILL / disk-full mid-write leaves a truncated JSON, the next run's `JSONDecodeError` branch resets `prev_ids=[]`, and every existing candidate wakes the agent spuriously. Switched to tempfile + fsync + `os.replace` (same atomic-write pattern as `follow-me-two-phase-lock.md`).

## Known conflict

PR #3 also modifies `skills/check-unanswered/scripts/unanswered-precheck.py` (adds env-warning handling). Whichever PR merges second will need a trivial rebase — the regions touched don't semantically overlap, but git will see them as close edits. Flagging now so the merge isn't a surprise.

## Not included

- `rules/default-silence.md` (covered by open PR #4).
- `skills/check-unanswered/SKILL.md` (covered by open PR #3).
- Initial promote run auto-optimized `SKILL.md` via `tessl skill review`; reverted in the follow-up commit on this branch (`1b79d3a`) to keep this PR scoped to the five findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)