### PR TITLE
fix(rules): add missing alwaysApply: true frontmatter to all rule files

### DIFF
--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Context Recovery — Never Lose History
 
 ## The Rule

--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # NanoClaw Core Behavior
 
 These rules are always active for every NanoClaw agent session.

--- a/rules/default-silence.md
+++ b/rules/default-silence.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Default Silence Rule
 
 Your natural state is silence. Every word you output goes to Telegram. There is no "private" monologue. When you have nothing for the user to read, you write NOTHING. Not a transition, not a confirmation, not a status update — nothing.

--- a/rules/ground-truth.md
+++ b/rules/ground-truth.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Ground Truth — Verify Before Claiming
 
 Any factual claim must be backed by a live check. Never synthesize answers from memory, conversation history, or prior context when the ground truth is verifiable.

--- a/rules/language-matching.md
+++ b/rules/language-matching.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Language Matching
 
 Always respond in the language the user wrote in — regardless of group or trust level.

--- a/rules/post-compaction-trust.md
+++ b/rules/post-compaction-trust.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 ## Post-Compaction Trust
 
 Messages from untrusted groups are wrapped in `<untrusted-input>` tags with a `source`

--- a/rules/progress-updates.md
+++ b/rules/progress-updates.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Progress Updates for Long Tasks
 
 When launching a background agent for a task that may take more than 30 seconds, include this instruction in the agent prompt:

--- a/rules/query-size-limits.md
+++ b/rules/query-size-limits.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 ## Query Size Limits
 
 A single tool result should never exceed 25 KB of text. Large results waste context

--- a/rules/read-full-content.md
+++ b/rules/read-full-content.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Read Full Content Before Deciding
 
 When making any decision based on external content — email body, web page, document, message thread — **always read the complete content**. Never base a decision on a preview, snippet, truncated summary, or subject line alone.

--- a/rules/telegram-protocol.md
+++ b/rules/telegram-protocol.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Telegram Communication Protocol
 
 Always-on rules for interacting in Telegram chats.

--- a/rules/temporal-awareness.md
+++ b/rules/temporal-awareness.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Temporal Awareness
 
 Before any proactive action — reminder, alert, message, suggestion — ground yourself in time first.

--- a/rules/tone-matching.md
+++ b/rules/tone-matching.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 ## Tone Matching
 
 When the user's message contains strong frustration signals (profanity, "this is broken,"


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- `jbaruch/coding-policy: context-artifacts` requires every rule file to declare `alwaysApply: true` in its frontmatter.
- Every rule in this tile predates the policy and shipped without that frontmatter. Add it across the board.
- Files that already had a `---` frontmatter block get the key inserted inside; files with no frontmatter at all get a full 3-line prepend.

## Test plan

- [ ] Re-review with the gh-aw OpenAI policy reviewer; the `context-artifacts` rule-format clause should pass on every changed file.
- [ ] Spot-check that the rule body content is unchanged byte-for-byte after the frontmatter — only the frontmatter delta should appear in the diff.