### PR TITLE
fix(telegram-protocol): forbid &apos; / &quot; — Telegram doesn't decode them

### DIFF
--- a/rules/telegram-protocol.md
+++ b/rules/telegram-protocol.md
@@ -58,4 +58,9 @@ React → work → deliver result. Do NOT hold the user hostage with a reply tha
 
 For bullets use `•` (not `-` or `*`). For emphasis in lists, combine: `• <b>Item</b> — description`.
 
-Special characters `<`, `>`, `&` in user data must be escaped as `&lt;`, `&gt;`, `&amp;`.
+Special characters in user data: only `<`, `>`, and `&` need HTML-entity escaping (`&lt;`, `&gt;`, `&amp;`). Apostrophes (`'`) and double quotes (`"`) pass through raw — do NOT escape them as `&apos;` / `&quot;`. Telegram's HTML parse mode does not decode those entities; users see the literal `&apos;` / `&quot;` in the rendered message. Reference incident: 2026-04-26 untrusted group msg 1116, where `Baruch&apos;s Office` and `someone&apos;s tracing` rendered verbatim.
+
+**Forbidden patterns** (alongside the Markdown ban list above):
+
+- `&apos;` → use `'` directly
+- `&quot;` → use `"` directly


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Closes #11.

## Summary

The rule said "escape special characters \`<\`, \`>\`, \`&\`" — correct, but the model interpreted "escape special characters" too broadly and reached for \`&apos;\` / \`&quot;\` even though they're not in Telegram's allowed entity set. Telegram passes those entities through unchanged, so \`Baruch&apos;s Office\` rendered verbatim in the untrusted group on 2026-04-26 (msg 1116, screenshotted by @ligolnik).

Tighten:
- explicit "only \`<\`, \`>\`, \`&\` need escaping" framing
- explicit "apostrophes and quotes pass through raw, do NOT escape them as \`&apos;\` / \`&quot;\`"
- forbidden-patterns bullets next to the existing Markdown ban list

## Test plan

- [ ] OpenAI policy reviewer passes.
- [ ] Visual eyeball of the rule body — the new wording reads naturally inline with the existing Markdown ban bullets above.