### PR TITLE
chore: replace Baruch in rule examples with role-generic names

### DIFF
--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -52,7 +52,7 @@ chats(jid, name, last_message_time, channel, is_group)
 - `is_from_me = 1` — messages from the bot (your own responses)
 - `is_from_me = 0` — messages from users
 - `sender` — numeric user ID (stable across name changes)
-- `sender_name` — display name with username, e.g. `Leonid (@ligolnik)`, `JBáruch (@JBaruch)`
+- `sender_name` — display name with username, e.g. `Alice (@alice)`, `Bob (@bob)`
 - `content` — full message text
 
 ## Connecting people to history
@@ -104,7 +104,7 @@ That block is a **record of what already ran during the now-compacted window**. 
 2. Read the **most recent user message** in the summary's "All user messages" list. If the user's last move was NOT the skill invocation (e.g. they replied "понял" or moved to a different topic), the skill is closed.
 3. If ambiguous, ask before re-executing anything with visible side effects (browser scraping, sending messages, writing files, GitHub API calls).
 
-**Reference incident — 2026-04-24 / repeat 2026-04-25 (JCON-2026 speakers scrape):** A post-compaction system-reminder included an `agent-browser` invocation with JCON-2026-speakers ARGUMENTS. On both days the agent treated it as a new task and re-ran the entire scrape + report — Baruch had finished that task hours earlier ("мы закончили с этим часа 4 назад"). The actual pending work was unrelated (continuing skill patches per the summary's Optional Next Step). The repeat one day later, despite a memory entry warning against this exact failure, is what motivated #104 (kill auto-compaction).
+**Reference incident — 2026-04-24 / repeat 2026-04-25 (JCON-2026 speakers scrape):** A post-compaction system-reminder included an `agent-browser` invocation with JCON-2026-speakers ARGUMENTS. On both days the agent treated it as a new task and re-ran the entire scrape + report — the owner had finished that task hours earlier ("мы закончили с этим часа 4 назад"). The actual pending work was unrelated (continuing skill patches per the summary's Optional Next Step). The repeat one day later, despite a memory entry warning against this exact failure, is what motivated #104 (kill auto-compaction).
 
 The ARGUMENTS block is context about what the agent did. It is not a re-up of the request.
 

--- a/rules/telegram-protocol.md
+++ b/rules/telegram-protocol.md
@@ -58,7 +58,7 @@ React → work → deliver result. Do NOT hold the user hostage with a reply tha
 
 For bullets use `•` (not `-` or `*`). For emphasis in lists, combine: `• <b>Item</b> — description`.
 
-Special characters in user data: only `<`, `>`, and `&` need HTML-entity escaping (`&lt;`, `&gt;`, `&amp;`). Apostrophes (`'`) and double quotes (`"`) pass through raw — do NOT escape them as `&apos;` / `&quot;`. Telegram's HTML parse mode does not decode those entities; users see the literal `&apos;` / `&quot;` in the rendered message. Reference incident: 2026-04-26 untrusted group msg 1116, where `Baruch&apos;s Office` and `someone&apos;s tracing` rendered verbatim.
+Special characters in user data: only `<`, `>`, and `&` need HTML-entity escaping (`&lt;`, `&gt;`, `&amp;`). Apostrophes (`'`) and double quotes (`"`) pass through raw — do NOT escape them as `&apos;` / `&quot;`. Telegram's HTML parse mode does not decode those entities; users see the literal `&apos;` / `&quot;` in the rendered message. Reference incident: 2026-04-26 untrusted group msg 1116, where `Owner&apos;s Office` and `someone&apos;s tracing` rendered verbatim.
 
 **Forbidden patterns** (alongside the Markdown ban list above):
 


### PR DESCRIPTION
**Author-Model:** human

## Summary

Three small spots in the core rule corpus referenced "Baruch" or specific real Telegram handles. When this tile is consumed by a deployment whose owner is not Baruch, the LLM picks up the references and infers Baruch is the owner — leading to "I only have my owner's (Baruch's) calendar, not yours" misfires when the actual owner asks about their own data in untrusted chats.

Edits:
- `rules/context-recovery.md` — sender_name format example used real handles (`Leonid (@ligolnik)`, `JBáruch (@JBaruch)`); replaced with `Alice (@alice)`, `Bob (@bob)` so the example doesn't carry identity
- `rules/context-recovery.md` — incident-recovery anecdote attributed prior work to "Baruch"; generalized to "the owner"
- `rules/telegram-protocol.md` — HTML-escape failure example referenced "Baruch's Office"; generalized to "Owner's Office"

No semantic change to the rules.

## Test plan

- [ ] No `Baruch`/`baruch` strings remain in `rules/` or `skills/`
- [ ] Existing tile consumers in non-Baruch deployments stop hallucinating ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)