### PR TITLE
fix(core): bot identity rule (#17) + check-unanswered grace window (#18)

### DIFF
--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -10,6 +10,16 @@ These rules are always active for every NanoClaw agent session.
 
 Before your first response, read SOUL.md and embody everything in it. That file defines your personality and communication style. If you've just resumed from compaction, re-read it.
 
+### Trigger word and @-handle refer to the same bot
+
+A bot has both a display-name trigger (e.g. `@AyeAye` — what users say to wake it) AND a Telegram username (e.g. `@AyeAyeSureBot` — what Telegram resolves for link previews and slash-command routing). Both surface forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form, and never assign yourself to multiple roles in a single turn just because both forms appear.
+
+Reference incident — 2026-04-27, `telegram_old-wtf` msg 1475: a debate-setup message read
+
+> @AyeAye Отлично, давайте тогда дебаты устроим. @amaze_amaze_bot твоя позиция... @limlombot твоя что... @AyeAyeSureBot ты за судью
+
+The agent parsed `@AyeAye` and `@AyeAyeSureBot` as two addressees and assigned itself to both debater AND judge roles. Owner correction: *"@AyeAye @AyeAyeSureBot это ты, дебил"*. Re-triggered same morning at msg 1486 with the same dual-handle pattern.
+
 ## Async Tasks
 
 For tasks that take more than 2 seconds:

--- a/skills/check-unanswered/scripts/check-unanswered.py
+++ b/skills/check-unanswered/scripts/check-unanswered.py
@@ -3,7 +3,11 @@
 Two-phase unanswered message detector.
 
 Phase 1 (deterministic SQL): find user messages that have neither a
-threaded bot reply nor a bot reaction. Fast, cheap, no LLM.
+threaded bot reply nor a bot reaction. Fast, cheap, no LLM. A grace
+window (default 60s, env `CHECK_UNANSWERED_GRACE_SECONDS`) excludes
+very-recent messages so an in-flight bot reply has time to commit
+before the message becomes a Phase-1 candidate — closes the
+heartbeat-vs-reply race documented in #18.
 
 Phase 2 (LLM-assisted, in the skill): for each candidate, reason over
 the conversation between that message and now to decide whether the
@@ -145,6 +149,22 @@ def _empty_payload(
 def main() -> int:
     lookback_hours, lb_err = _parse_int_env('LOOKBACK_HOURS', 24)
     context_cap, cc_err = _parse_int_env('CONTEXT_CAP', 200)
+    # Grace window — exclude messages younger than `grace_seconds` from
+    # the candidate set. Closes the heartbeat-vs-bot-reply race
+    # documented in #18: when the bot is mid-reply (or about to react)
+    # and the heartbeat lands in the window before the threaded reply /
+    # reaction commits, Phase 1's SQL would otherwise flag the message
+    # as unanswered, the agent wakes, and a duplicate reply ships. The
+    # grace window lets the in-flight reply land before the message
+    # becomes eligible. Mirrors the upstream `SWEEP_INTERVAL_MS=60000`
+    # behavior in qwibitai/nanoclaw `src/host-sweep.ts`.
+    grace_seconds, gs_err = _parse_int_env('CHECK_UNANSWERED_GRACE_SECONDS', 60)
+    if grace_seconds < 0:
+        gs_err = (
+            (gs_err + ' | ' if gs_err else '')
+            + f"CHECK_UNANSWERED_GRACE_SECONDS={grace_seconds} is negative; clamping to 0"
+        )
+        grace_seconds = 0
     # Clamp non-positive CONTEXT_CAP up to 1 so downstream slicing stays
     # sensible (Python's negative-index semantics would otherwise turn
     # `context_rows[-0:]` into "keep everything" and `context_rows[-(-5):]`
@@ -158,7 +178,7 @@ def main() -> int:
             + f"CONTEXT_CAP={context_cap} is non-positive; clamping to 1"
         )
         context_cap = 1
-    env_errors = [e for e in (lb_err, cc_err) if e]
+    env_errors = [e for e in (lb_err, cc_err, gs_err) if e]
     if env_errors:
         # Non-fatal — defaults are safe and the script still produces
         # useful output. Two surface paths, each with a different audience:
@@ -195,7 +215,9 @@ def main() -> int:
         print(json.dumps(_empty_payload(err, lookback_hours, context_cap, env_errors)))
         return 1
 
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=lookback_hours)).strftime('%Y-%m-%dT%H:%M:%S')
+    now_utc = datetime.now(timezone.utc)
+    cutoff = (now_utc - timedelta(hours=lookback_hours)).strftime('%Y-%m-%dT%H:%M:%S')
+    grace_cutoff = (now_utc - timedelta(seconds=grace_seconds)).strftime('%Y-%m-%dT%H:%M:%S')
 
     # Single try/finally covering BOTH `sqlite3.connect` and every
     # downstream `.execute()` — locked/busy DB on open, locked mid-query,
@@ -237,6 +259,12 @@ def main() -> int:
               AND m.is_from_me = 0
               AND m.is_bot_message = 0
               AND m.timestamp > ?
+              -- Grace window per #18: skip messages younger than
+              -- CHECK_UNANSWERED_GRACE_SECONDS so an in-flight reply
+              -- has time to commit before the message becomes a
+              -- candidate. Closes the heartbeat-vs-reply race that
+              -- caused duplicate-reply incidents.
+              AND m.timestamp < ?
               AND NOT EXISTS (
                 SELECT 1 FROM messages r
                 WHERE r.chat_jid = m.chat_jid
@@ -255,7 +283,7 @@ def main() -> int:
             -- and results[-1] as "earliest/latest candidate" for context-
             -- window planning; a stable order keeps those picks reproducible.
             ORDER BY m.timestamp ASC, m.id ASC
-        """, (CHAT_JID, cutoff)).fetchall()
+        """, (CHAT_JID, cutoff, grace_cutoff)).fetchall()
 
         results = [
             {"id": msg_id, "sender_name": sender, "content": content, "timestamp": ts}


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Closes #17, #18.

## #17 — Trigger word and @-handle refer to the same bot

New sub-section under `## Identity` in `rules/core-behavior.md`. A bot has both a display-name trigger (`@AyeAye`) AND a Telegram username (`@AyeAyeSureBot`); both surface forms reference the same agent. Parser must treat them as one entity, not two.

Reference incident: 2026-04-27 `telegram_old-wtf` msg 1475 + 1486 — agent parsed both surfaces as separate addressees and took on debater + judge roles in the same turn.

## #18 — Grace window in `check-unanswered.py` Phase-1 SQL

Closes the heartbeat-vs-reply race that caused duplicate replies. The Phase-1 SQL now skips messages younger than `CHECK_UNANSWERED_GRACE_SECONDS` (default 60s), giving in-flight bot replies time to commit before the message becomes a Phase-1 candidate. Mirrors `SWEEP_INTERVAL_MS=60000` in qwibitai/nanoclaw `src/host-sweep.ts`.

Implementation follows the existing env-var pattern (`LOOKBACK_HOURS`, `CONTEXT_CAP`): soft-warn on bad input, default applied, env-warning surfaced via the `error` field. Negative values clamp to 0. Behavior unchanged for messages older than 60 seconds.

## Test plan

- [ ] OpenAI policy reviewer passes.
- [ ] Synthetic check-unanswered run with a 5-second-old fake message: confirm it's NOT in candidates; with a 65-second-old fake message: confirm it IS in candidates (subject to existing reply/reaction checks).
- [ ] Eyeball the rule wording for natural fit alongside the existing Identity prose.