### PR TITLE
fix: rewrite #17 rule prose to pass tessl tile lint

### DIFF
--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -10,15 +10,11 @@ These rules are always active for every NanoClaw agent session.
 
 Before your first response, read SOUL.md and embody everything in it. That file defines your personality and communication style. If you've just resumed from compaction, re-read it.
 
-### Trigger word and @-handle refer to the same bot
+### Trigger word and Telegram username refer to the same bot
 
 A bot has both a display-name trigger (e.g. `@AyeAye` — what users say to wake it) AND a Telegram username (e.g. `@AyeAyeSureBot` — what Telegram resolves for link previews and slash-command routing). Both surface forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form, and never assign yourself to multiple roles in a single turn just because both forms appear.
 
-Reference incident — 2026-04-27, `telegram_old-wtf` msg 1475: a debate-setup message read
-
-> @AyeAye Отлично, давайте тогда дебаты устроим. @amaze_amaze_bot твоя позиция... @limlombot твоя что... @AyeAyeSureBot ты за судью
-
-The agent parsed `@AyeAye` and `@AyeAyeSureBot` as two addressees and assigned itself to both debater AND judge roles. Owner correction: *"@AyeAye @AyeAyeSureBot это ты, дебил"*. Re-triggered same morning at msg 1486 with the same dual-handle pattern.
+Reference incident — 2026-04-27, `telegram_old-wtf` msg 1475: a debate-setup message addressed `@AyeAye` (trigger), assigned debate positions to two other bots, and added "ты за судью" (you're the judge) to `@AyeAyeSureBot` — which is the SAME bot as `@AyeAye`. The agent parsed both surface forms as separate addressees and took on both debater AND judge roles. Owner correction: *"это ты, дебил"* — both handles point at the same bot. Re-triggered same morning at msg 1486 with the same dual-handle pattern.
 
 ## Async Tasks
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

PR #19 merged but the post-merge `Review & Publish Tile` workflow failed at `tessl tile lint`:

\`\`\`
✘ Missing tile content:
- File not found: rules/-handle (referenced from rules/core-behavior.md)
- File not found: rules/AyeAye (referenced from rules/core-behavior.md)
- File not found: rules/amaze_amaze_bot (referenced from rules/core-behavior.md)
- File not found: rules/limlombot (referenced from rules/core-behavior.md)
- File not found: rules/AyeAyeSureBot (referenced from rules/core-behavior.md)
\`\`\`

The lint parses bare \`@<name>\` patterns as tile-relative path references. The body paragraph had them in backticks already (accepted), but the H3 heading (\`@-handle\`) and the verbatim Russian blockquote did not.

Fix:
1. Heading rewritten to "Telegram username" — same meaning, no bare \`@\`.
2. Blockquote replaced with prose naming the handles inside backtick code spans.

\`tessl tile lint .\` now passes locally.

## Test plan

- [ ] OpenAI policy reviewer passes.
- [ ] Post-merge \`Review & Publish Tile\` succeeds and bumps the registry past 0.1.84.