### PR TITLE
fix(skills/status): compute container uptime from /.dockerenv mtime (jbaruch/nanoclaw#243)

### DIFF
--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -23,7 +23,13 @@ echo "Channel: main"
 
 ### 2. Container uptime
 
-Run `python3 /home/node/.claude/skills/tessl__status/scripts/container-uptime.py` — outputs single-line JSON `{"uptime_text": "<Nd Hh (since ISO8601)>", "started": "<ISO8601>"}`. Use the `uptime_text` field as the rendered line. On a non-container host (no `/.dockerenv`), `uptime_text` is `"unknown"` and `started` is `null`.
+Run the `container-uptime.py` script (`scripts/container-uptime.py` relative to this skill, mounted into the agent at `/home/node/.claude/skills/tessl__status/scripts/container-uptime.py` — the absolute path matches every other `tessl__*` skill in this tile and is what the agent must literally invoke):
+
+```bash
+python3 /home/node/.claude/skills/tessl__status/scripts/container-uptime.py | python3 -c 'import json,sys; print(json.load(sys.stdin)["uptime_text"])'
+```
+
+The script outputs single-line JSON `{"uptime_text": "<Nd Hh (since ISO8601)>", "started": "<ISO8601>"}`. The pipe extracts `uptime_text` for direct rendering. On a non-container host (no `/.dockerenv`), `uptime_text` is `"unknown"` and `started` is `null`.
 
 Reads `/.dockerenv` mtime, which Docker creates at container spawn time. Cross-tier safe — the file exists in every container regardless of trust level, so this works on untrusted, trusted, and main alike with no external state file.
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -23,20 +23,9 @@ echo "Channel: main"
 
 ### 2. Container uptime
 
-Compute container uptime from `/.dockerenv` mtime — this file is created at container spawn time and exists in every container regardless of trust tier, so reading it works on untrusted, trusted, and main alike. No external state file required.
+Run `python3 /home/node/.claude/skills/tessl__status/scripts/container-uptime.py` — outputs single-line JSON `{"uptime_text": "<Nd Hh (since ISO8601)>", "started": "<ISO8601>"}`. Use the `uptime_text` field as the rendered line. On a non-container host (no `/.dockerenv`), `uptime_text` is `"unknown"` and `started` is `null`.
 
-```python
-import datetime, os
-try:
-    epoch = os.path.getmtime('/.dockerenv')
-except OSError:
-    print("unknown")
-else:
-    started_dt = datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
-    started = started_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
-    age = datetime.datetime.now(datetime.timezone.utc) - started_dt
-    print(f"{age.days}d {age.seconds // 3600}h (since {started})")
-```
+Reads `/.dockerenv` mtime, which Docker creates at container spawn time. Cross-tier safe — the file exists in every container regardless of trust level, so this works on untrusted, trusted, and main alike with no external state file.
 
 ### 3. Workspace and mount visibility
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -23,24 +23,19 @@ echo "Channel: main"
 
 ### 2. Container uptime
 
-Read `container_started` from `/workspace/group/session-state.json` and compute age:
+Compute container uptime from `/.dockerenv` mtime — this file is created at container spawn time and exists in every container regardless of trust tier, so reading it works on untrusted, trusted, and main alike. No external state file required.
 
 ```python
-import json, datetime
-state = json.load(open('/workspace/group/session-state.json'))
-started = state.get('container_started')
-if started:
-    now = datetime.datetime.now(datetime.timezone.utc)
-    # endswith-slice instead of `.replace("Z", ...)` — `.replace`
-    # would corrupt any timestamp that contains 'Z' inside a numeric
-    # offset (`+0Z00`-style malformed strings) or in microsecond
-    # precision. The 'Z' suffix is positional; treat it that way.
-    iso = started[:-1] + '+00:00' if started.endswith('Z') else started
-    started_dt = datetime.datetime.fromisoformat(iso)
-    age = now - started_dt
-    print(f"{age.days}d {age.seconds // 3600}h (since {started})")
-else:
+import datetime, os
+try:
+    epoch = os.path.getmtime('/.dockerenv')
+except OSError:
     print("unknown")
+else:
+    started_dt = datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
+    started = started_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+    age = datetime.datetime.now(datetime.timezone.utc) - started_dt
+    print(f"{age.days}d {age.seconds // 3600}h (since {started})")
 ```
 
 ### 3. Workspace and mount visibility

--- a/skills/status/scripts/container-uptime.py
+++ b/skills/status/scripts/container-uptime.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Compute container uptime from /.dockerenv mtime.
+
+`/.dockerenv` is created by Docker at container spawn time and is
+present in every container regardless of trust tier (untrusted,
+trusted, main), so this script is safe to call from any cross-tier
+skill that needs container start time.
+
+Output (single-line JSON to stdout):
+    {"uptime_text": "<Nd Hh (since ISO8601)>", "started": "<ISO8601 UTC>"}
+                            on success
+    {"uptime_text": "unknown", "started": null}
+                            when /.dockerenv is missing (e.g. running
+                            on a dev host outside a container)
+
+Exit codes:
+    0 — always. The missing-/.dockerenv case is an expected
+        non-container environment, not a failure; the JSON payload
+        signals it via `started: null`.
+
+Stderr is unused on the happy path. Unexpected errors propagate as
+non-zero exits with the Python traceback on stderr (per
+`jbaruch/coding-policy: error-handling`).
+"""
+import datetime
+import json
+import os
+import sys
+
+
+DOCKERENV_PATH = "/.dockerenv"
+
+
+def compute_uptime(now: datetime.datetime) -> dict:
+    """Pure function — takes 'now' as input so tests can pin time."""
+    try:
+        epoch = os.path.getmtime(DOCKERENV_PATH)
+    except FileNotFoundError:
+        return {"uptime_text": "unknown", "started": None}
+    started_dt = datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
+    started = started_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    age = now - started_dt
+    uptime_text = f"{age.days}d {age.seconds // 3600}h (since {started})"
+    return {"uptime_text": uptime_text, "started": started}
+
+
+def main() -> int:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = compute_uptime(now)
+    json.dump(payload, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/status/scripts/container-uptime.py
+++ b/skills/status/scripts/container-uptime.py
@@ -14,13 +14,15 @@ Output (single-line JSON to stdout):
                             on a dev host outside a container)
 
 Exit codes:
-    0 — always. The missing-/.dockerenv case is an expected
-        non-container environment, not a failure; the JSON payload
-        signals it via `started: null`.
+    0 — success path: container present (`/.dockerenv` exists) OR the
+        expected non-container environment (missing `/.dockerenv`,
+        signalled via `started: null` in the JSON payload).
+    >0 — unexpected error (e.g. permissions, OS-level fault). The
+        Python traceback propagates to stderr per
+        `jbaruch/coding-policy: error-handling`; we do NOT swallow
+        unexpected exceptions.
 
-Stderr is unused on the happy path. Unexpected errors propagate as
-non-zero exits with the Python traceback on stderr (per
-`jbaruch/coding-policy: error-handling`).
+Stderr is unused on the happy path.
 """
 import datetime
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,14 @@ def check_unanswered():
         "check_unanswered_under_test",
         "skills/check-unanswered/scripts/check-unanswered.py",
     )
+
+
+@pytest.fixture
+def container_uptime():
+    """Fresh-loaded module under test for the status skill's
+    container-uptime script. Per-test reload keeps tests independent
+    even though this module reads no module-level env."""
+    return _load(
+        "container_uptime_under_test",
+        "skills/status/scripts/container-uptime.py",
+    )

--- a/tests/test_container_uptime.py
+++ b/tests/test_container_uptime.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "skills/status/scripts/container-uptime.py"

--- a/tests/test_container_uptime.py
+++ b/tests/test_container_uptime.py
@@ -1,0 +1,100 @@
+"""Tests for skills/status/scripts/container-uptime.py — the script
+the `status` skill calls to compute container uptime cross-tier.
+
+The module exposes `compute_uptime(now)` as a pure function: it takes
+a fixed `now` so tests can pin time and assert deterministic output.
+The CLI entrypoint (`main`) is just a JSON-printer wrapper.
+"""
+import datetime
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "skills/status/scripts/container-uptime.py"
+
+
+# Pinned test inputs — keeps the test deterministic per
+# `jbaruch/coding-policy: testing-standards` ("Tests must be
+# deterministic — no self-generated random test data").
+FIXED_DOCKERENV_EPOCH = 1_700_000_000  # 2023-11-14T22:13:20Z
+FIXED_NOW = datetime.datetime(
+    2023, 11, 16, 22, 13, 20, tzinfo=datetime.timezone.utc
+)  # exactly 2 days, 0 hours later
+
+
+def test_missing_dockerenv_returns_unknown(container_uptime, monkeypatch):
+    """When /.dockerenv is absent (dev host, non-container env),
+    compute_uptime must return the unknown shape — `started: None`,
+    `uptime_text: "unknown"`. Per the script's docstring this is an
+    expected case, NOT an error: status skill renders it as 'unknown'
+    instead of failing."""
+    monkeypatch.setattr(container_uptime, "DOCKERENV_PATH", "/nonexistent/.dockerenv")
+    result = container_uptime.compute_uptime(FIXED_NOW)
+    assert result == {"uptime_text": "unknown", "started": None}
+
+
+def test_present_dockerenv_returns_deterministic_uptime(
+    container_uptime, monkeypatch, tmp_path
+):
+    """With a /.dockerenv at a fixed mtime and `now` pinned to exactly
+    2 days later, compute_uptime must produce '2d 0h (since <ISO>)'
+    and the matching ISO timestamp. Tests both branches of the format
+    string (days, hours-after-int-divide) by construction."""
+    fake_dockerenv = tmp_path / ".dockerenv"
+    fake_dockerenv.touch()
+    os.utime(fake_dockerenv, (FIXED_DOCKERENV_EPOCH, FIXED_DOCKERENV_EPOCH))
+    monkeypatch.setattr(container_uptime, "DOCKERENV_PATH", str(fake_dockerenv))
+
+    result = container_uptime.compute_uptime(FIXED_NOW)
+
+    assert result["started"] == "2023-11-14T22:13:20Z"
+    assert result["uptime_text"] == "2d 0h (since 2023-11-14T22:13:20Z)"
+
+
+def test_partial_day_uptime_formats_hours(container_uptime, monkeypatch, tmp_path):
+    """Pin mtime to 5 hours before `now` (less than 1 day) — must
+    render as '0d 5h ...' so the day/hour split is correct on
+    sub-day uptimes too. Catches off-by-one or wrong-units bugs in
+    the format string."""
+    fake_dockerenv = tmp_path / ".dockerenv"
+    fake_dockerenv.touch()
+    five_hours_before_now = int(FIXED_NOW.timestamp()) - (5 * 3600)
+    os.utime(fake_dockerenv, (five_hours_before_now, five_hours_before_now))
+    monkeypatch.setattr(container_uptime, "DOCKERENV_PATH", str(fake_dockerenv))
+
+    result = container_uptime.compute_uptime(FIXED_NOW)
+
+    assert result["started"] == "2023-11-16T17:13:20Z"
+    assert result["uptime_text"].startswith("0d 5h")
+
+
+def test_main_emits_single_line_json(tmp_path):
+    """The CLI entrypoint must produce a single-line JSON payload on
+    stdout that downstream callers can parse (the SKILL.md example
+    pipes through `python3 -c 'json.load(sys.stdin)'`). Run as a
+    subprocess with HOME pointed at tmp_path so we don't depend on
+    the test runner's environment, and so the script's
+    `os.path.getmtime('/.dockerenv')` falls through to the missing
+    branch on the test host."""
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Single line plus trailing newline — the script writes
+    # `json.dump(...)` then `'\n'` explicitly.
+    assert completed.stdout.endswith("\n")
+    payload = json.loads(completed.stdout)
+    # On the test host /.dockerenv almost certainly doesn't exist, so
+    # we expect the unknown shape. (If it does exist, we still have a
+    # well-formed JSON payload, which is the contract we're verifying.)
+    assert "uptime_text" in payload
+    assert "started" in payload
+    if payload["started"] is None:
+        assert payload["uptime_text"] == "unknown"

--- a/tests/test_container_uptime.py
+++ b/tests/test_container_uptime.py
@@ -5,13 +5,13 @@ The module exposes `compute_uptime(now)` as a pure function: it takes
 a fixed `now` so tests can pin time and assert deterministic output.
 The CLI entrypoint (`main`) is just a JSON-printer wrapper.
 """
+
 import datetime
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "skills/status/scripts/container-uptime.py"
@@ -37,9 +37,7 @@ def test_missing_dockerenv_returns_unknown(container_uptime, monkeypatch):
     assert result == {"uptime_text": "unknown", "started": None}
 
 
-def test_present_dockerenv_returns_deterministic_uptime(
-    container_uptime, monkeypatch, tmp_path
-):
+def test_present_dockerenv_returns_deterministic_uptime(container_uptime, monkeypatch, tmp_path):
     """With a /.dockerenv at a fixed mtime and `now` pinned to exactly
     2 days later, compute_uptime must produce '2d 0h (since <ISO>)'
     and the matching ISO timestamp. Tests both branches of the format


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Closes (in spirit) `jbaruch/nanoclaw#243` — Cat 4 of `jbaruch/nanoclaw#99`. Paired with `jbaruch/nanoclaw-host#16` for the cross-tier convention rule.

## Summary

`skills/status/SKILL.md` previously read `container_started` from `/workspace/group/session-state.json`. This PR drops the JSON read entirely and computes container uptime directly from `/.dockerenv` mtime — present in every container regardless of trust tier, accurate to the actual spawn time, no external state needed.

## Why this differs from the literal scope in jbaruch/nanoclaw#243

The issue's stated plan was to migrate the read path to `/workspace/state/status/session-state.json` plus a one-shot legacy migration. After investigating, two facts changed the right approach:

1. **No writer of `container_started` exists in the entire codebase.** Greps across `src/`, `container/`, `scripts/`, every tile's skills, and NAS group folders found no code that writes this field. Production files have stale values from April 17 even though `session-state.json` itself has been updated as recently as today (the legacy field is preserved across read-modify-writes by other writers but never refreshed). The status skill has been reading 11-day-stale data and reporting it as "container uptime".
2. **The issue's "copy then remove the legacy file" plan would clobber other consumers.** `nanoclaw-trusted/trusted-memory/scripts/register-session.py`, `nanoclaw-admin/check-email/scripts/append-seen-ids.py`, and others read-modify-write the same `session-state.json` for fields they own (`sessions.<name>`, `seen_email_ids`, `pending_response`). Removing the file as part of the status migration would erase admin's seen-email-IDs list (currently 252 entries on the production main group).

`/.dockerenv` mtime is the canonical source per the existing repo notes (`blog-notes.md:518`: *"The container has a birthday: `/.dockerenv` is created at spawn time. `stat -c '%Y' /.dockerenv` gives the epoch timestamp."*). Reading it directly:

- Eliminates the cross-skill dependency that made this issue exist.
- Always returns fresh data instead of legacy-stale data.
- Works on every trust tier (`/.dockerenv` is written by Docker itself, present everywhere).
- Removes the need for any writer-side change.

## What changed

- `skills/status/SKILL.md` step 2 — reads `os.path.getmtime('/.dockerenv')` instead of opening `/workspace/group/session-state.json`. Same output format.

## Test plan

- [x] Dry-run the new Python on this Mac (Docker Desktop, `/.dockerenv` doesn't exist on host) — falls through to "unknown" cleanly.
- [ ] Live verification on the next deploy — `/status` should report a non-stale uptime that matches the actual spawn time.

## Convention

The cross-trust-tier path-storage convention lives in the paired host PR `jbaruch/nanoclaw-host#16` (`rules/host-conventions.md`).

Tracks `jbaruch/nanoclaw#243`.