### PR TITLE
docs(rules): #302 update temporal-awareness current_tz lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules
+
+- **`temporal-awareness.md` — `current_tz` lookup updated for the SQLite migration** (`jbaruch/nanoclaw#302`). The "What time is it?" check now points at `SELECT current_tz FROM tz_state WHERE id = 1` in `/workspace/store/messages.db` instead of the retired `task-tz-state.json` envelope. The reasoning the rule asks for (UTC, owner local, jet-lag, in-flight-state) is unchanged; only the storage handle moves.
+
 ### Test infrastructure
 
 - **pytest baseline + CI gate** (new) — Mirrors the `nanoclaw-admin#59` / `nanoclaw-trusted#11` scaffold: `pyproject.toml` carries `[tool.pytest.ini_options]` and a `tests/`-scoped ruff config; `requirements-dev.txt` pins `pytest==8.3.4` and `ruff==0.7.4`; `.github/workflows/test.yml` runs `ruff check tests/`, `ruff format --check tests/`, then `python -m pytest` on every PR and push to `main`. Initial coverage targets `skills/check-unanswered/scripts/check-unanswered.py` per the issue: `_make_payload` shape contract (every key present on success and error paths), the `env-warning:` prefix path through `_merge_env_warnings`, and `main()`'s missing-`NANOCLAW_CHAT_JID` early-exit. Closes the core slice of `nanoclaw-admin#55`. Other tile scripts get coverage in follow-up PRs.

--- a/rules/temporal-awareness.md
+++ b/rules/temporal-awareness.md
@@ -8,7 +8,7 @@ Before any proactive action — reminder, alert, message, suggestion — ground 
 
 ## The check (before every proactive action)
 
-1. **What time is it?** Know the current UTC time and the owner's local time (from `current_tz` in `task-tz-state.json`). When traveling, these differ from the server timezone. Don't assume.
+1. **What time is it?** Know the current UTC time and the owner's local time (from `current_tz` in the `tz_state` singleton: `SELECT current_tz FROM tz_state WHERE id = 1` in `/workspace/store/messages.db`). When traveling, these differ from the server timezone. Don't assume.
 
 2. **What's happening right now?** Use calendar and travel context. Is the owner in-flight? In a meeting? Asleep? Between events? A thing that made sense to schedule at 7am may not make sense to fire at noon if circumstances changed.
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Tiny tile-side companion to the larger admin-tile rewrite at jbaruch/nanoclaw-admin#141. Closes the core-tile slice of jbaruch/nanoclaw#302 (epic jbaruch/nanoclaw#293).

## What changes

`rules/temporal-awareness.md` line 11: the "What time is it?" check now points at `SELECT current_tz FROM tz_state WHERE id = 1` in `/workspace/store/messages.db` instead of the retired `task-tz-state.json` envelope. The reasoning the rule asks for is unchanged; only the storage handle moves.

## Why a separate PR

`temporal-awareness` lives in `nanoclaw-core`, the rest of the surface lives in `nanoclaw-admin`. Cross-repo PRs aren't possible; per the host conventions both go through their own repo's normal PR flow.

## Test plan

- [x] No tests touched — rule prose change only
- [ ] Confirm CI passes (no functional code changes; `tessl rule lint` should be clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)