### PR TITLE
docs(rules): #36 strip deploy specifics from core-behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Rules
 
+- **`core-behavior.md` — strip deploy-specific examples from the dual-handle section** (`jbaruch/nanoclaw-core#36`). The "Trigger word and Telegram username refer to the same bot" subsection used one specific deployment's bot pair as its only example and embedded an entire reference-incident block (group name, two live message IDs, a quoted message in another language) — both inappropriate for a deploy-anywhere universal tile. Replaced with abstract prose that cites the runtime identity preamble (`ASSISTANT_NAME` / `ASSISTANT_USERNAME`) as the authoritative source for the handle pair. The universal failure mode ("don't split yourself into multiple addressees based on surface form") is preserved verbatim. The relocated incident lives in `nanoclaw-trusted` as a deploy-tier reference; the runtime preamble fix that prevents the underlying confusion is in flight separately on `jbaruch/nanoclaw-public`.
+
 - **`temporal-awareness.md` — `current_tz` lookup updated for the SQLite migration** (`jbaruch/nanoclaw#302`). The "What time is it?" check now points at `SELECT current_tz FROM tz_state WHERE id = 1` in `/workspace/store/messages.db` instead of the retired `task-tz-state.json` envelope. The reasoning the rule asks for (UTC, owner local, jet-lag, in-flight-state) is unchanged; only the storage handle moves.
 
 ### Test infrastructure

--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -12,9 +12,7 @@ Before your first response, read SOUL.md and embody everything in it. That file 
 
 ### Trigger word and Telegram username refer to the same bot
 
-A bot has both a display-name trigger (e.g. `@AyeAye` — what users say to wake it) AND a Telegram username (e.g. `@AyeAyeSureBot` — what Telegram resolves for link previews and slash-command routing). Both surface forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form, and never assign yourself to multiple roles in a single turn just because both forms appear.
-
-Reference incident — 2026-04-27, `telegram_old-wtf` msg 1475: a debate-setup message addressed `@AyeAye` (trigger), assigned debate positions to two other bots, and added "ты за судью" (you're the judge) to `@AyeAyeSureBot` — which is the SAME bot as `@AyeAye`. The agent parsed both surface forms as separate addressees and took on both debater AND judge roles. Owner correction: *"это ты, дебил"* — both handles point at the same bot. Re-triggered same morning at msg 1486 with the same dual-handle pattern.
+On Telegram, a bot is addressable by two surface forms — a display-name trigger (what users type to wake it) and a Telegram `@username` (what Telegram resolves for link previews and slash-command routing). Both forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form, and never assign yourself to multiple roles in a single turn just because both forms appear. The authoritative bindings come from the runtime identity preamble (`ASSISTANT_NAME` / `ASSISTANT_USERNAME`); the rule applies to whatever pair of strings that preamble names.
 
 ## Async Tasks
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- Closes #36 — hygiene-only edit to `rules/core-behavior.md` (Identity → "Trigger word and Telegram username refer to the same bot").
- Removes the two `@AyeAye` / `@AyeAyeSureBot` example handles and the inline 2026-04-27 reference-incident block (group name, two live message IDs, foreign-language quote) — all deploy-specific content that doesn't belong in the deploy-anywhere universal tile.
- Replaces with abstract prose that names the runtime identity preamble (`ASSISTANT_NAME` / `ASSISTANT_USERNAME`) as the authoritative source for the handle pair the rule applies to. The universal failure-mode statement ("don't split yourself into multiple addressees based on surface form, don't take on multiple roles in one turn") is preserved.
- Companion PR on `jbaruch/nanoclaw-trusted` records the relocated incident as a deploy-tier reference under `rules/identity-dual-handle.md` (this PR doesn't depend on it — they can merge in either order).
- The runtime-side fix that prevents the *identity-theft* form of the same confusion class (`buildIdentityPreamble`) is in flight separately on `jbaruch/nanoclaw-public` per the issue.

## Why

Per the issue: tile content in `nanoclaw-core` should be readable and applicable by any deployment. Concrete bot handles + a live-deployment incident bake one operator's chat artifacts into supposedly-universal content and have been observed seeding identity-theft in untrusted-tier containers whose persona files don't pin identity explicitly.

## Test plan

- [ ] CI green (`Test` workflow runs ruff + pytest under `tests/`; this PR doesn't touch Python).
- [ ] `review-anthropic` and `review-openai` workflows complete (cross-family review per `coding-policy: author-model-declaration`; this PR is claude-authored, so the openai-family reviewer is the cross-family one).
- [ ] Manual read-through of `rules/core-behavior.md` confirms no `@AyeAye` / `@AyeAyeSureBot` / `telegram_old-wtf` / `1475` / `1486` strings remain.
- [ ] After merge, `publish-tile.yml` runs and bumps `tile.json` to the next minor.