### PR TITLE
perf(publish): use coding-policy skill-review composite action

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -31,7 +31,7 @@ jobs:
       # in jbaruch/coding-policy so improvements land once and propagate
       # to every consumer plugin.
       - name: Skill review (changed only)
-        uses: jbaruch/coding-policy/.github/actions/skill-review@main
+        uses: jbaruch/coding-policy/.github/actions/skill-review@b63f13ea80e92c784cf71fc74ed98f71b15f2aa2 # v0.x
         with:
           threshold: '85'
 

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -15,16 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Required by jbaruch/coding-policy/.github/actions/skill-review:
+          # the action runs `git diff $BEFORE..HEAD` to find changed skills.
+          # The action falls back to a depth-recovery fetch if needed, but
+          # `fetch-depth: 0` keeps the path predictable.
+          fetch-depth: 0
 
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
-      - name: Skill review — status
-        run: tessl skill review --threshold 85 skills/status/SKILL.md
-
-      - name: Skill review — query-history
-        run: tessl skill review --threshold 85 skills/query-history/SKILL.md
+      # Reviews only the skills whose files changed in this push, instead
+      # of always reviewing both skills regardless of change. Action lives
+      # in jbaruch/coding-policy so improvements land once and propagate
+      # to every consumer plugin.
+      - name: Skill review (changed only)
+        uses: jbaruch/coding-policy/.github/actions/skill-review@main
+        with:
+          threshold: '85'
 
       - name: Lint tile
         run: tessl tile lint .


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Replace the inline `Skill review` step in `publish-tile.yml` with a `uses:` call to `jbaruch/coding-policy/.github/actions/skill-review@main`.
- Action detects changed skills via `git diff $BEFORE..HEAD` and runs `tessl skill review` only on those — falls back to "review all" on `workflow_dispatch` / initial push / unreachable base.
- Add `fetch-depth: 0` on `actions/checkout` so the diff is predictable; the action does its own depth-recovery fetch as a fallback if needed.

## Why
Centralizes the diff-detection logic in `jbaruch/coding-policy` so future improvements to the gate (better fallback semantics, additional inputs, paths-filter handling, etc.) land once and propagate to every consumer plugin. Previously the same bash had to be copy-pasted into every plugin's publish workflow.

The action itself lands in coding-policy via [PR #69](https://github.com/jbaruch/coding-policy/pull/69) — that needs to merge before this PR can run cleanly on `main`. Order: AWF refresh → coding-policy action → this PR.

## Scope
CI configuration change, scoped explicitly per `jbaruch/coding-policy: ci-safety` — this PR's title and body are the approval artifact.

## Test plan
- [ ] After the action lands in `jbaruch/coding-policy@main`, merge this PR.
- [ ] Next push to main triggers `Review & Publish Tile`. Logs read `Detected N changed skill(s) since <sha>` and only the changed skills are reviewed.
- [ ] `workflow_dispatch` trigger logs `Reviewing all N skill(s)` and reviews everything.
- [ ] A merge that touches no skills logs `No skill changes — review skipped.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
