### PR TITLE
chore(rules): tier-3 connective + intensifier cuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Rules — conciseness pass tier 3 per `coding-policy: context-writing-style`
+
+- **core-behavior** — drop "just because both forms appear" because-clause from the dual-handle section. Operative directive ("Never assign yourself to multiple roles in a single turn") stays; the rationale clause goes.
+- **progress-updates** — replace "Two max for very long tasks" with "Two max for tasks beyond ~2 minutes". The `very` intensifier was carrying no constraint; the duration bound is the actual operative content.
+- **read-full-content** — drop `## Why` section entirely (3 lines of meta-justification: "Truncated previews optimize for speed at the cost of correctness. Re-doing work because of a wrong decision based on incomplete content is more expensive than reading fully once. There is no valid reason to use a preview when making a decision."). The operative content sits in `## The rule` and `## Applies to`.
+
 ### Rules
 
 - **Compression sweep on the three rules >40 lines** (`jbaruch/nanoclaw#552` step 2 of the `requires:` + compression + reorg plan) — Audit on `telegram_old-wtf` (trusted-tier baseline) measured RULES.md at 932 lines / 28 rules. The core-tile contribution is 402 lines / 12 rules. This PR compresses the three rules that exceed the `coding-policy: context-artifacts` ~25–40 line target, preserving every load-bearing fact (incident references, command contracts, distinguishing examples) and pruning redundant framing, multi-sentence elaborations of single bullets, and exhaustive enumerations:

--- a/rules/core-behavior.md
+++ b/rules/core-behavior.md
@@ -12,7 +12,7 @@ Before your first response, read SOUL.md and embody everything in it. That file 
 
 ### Trigger word and Telegram username refer to the same bot
 
-On Telegram, a bot is addressable by two surface forms — a display-name trigger (what users type to wake it) and a Telegram `@username` (what Telegram resolves for link previews and slash-command routing). Both forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form, and never assign yourself to multiple roles in a single turn just because both forms appear. The authoritative bindings come from the runtime identity preamble (`ASSISTANT_NAME` / `ASSISTANT_USERNAME`); the rule applies to whatever pair of strings that preamble names.
+On Telegram, a bot is addressable by two surface forms — a display-name trigger (what users type to wake it) and a Telegram `@username` (what Telegram resolves for link previews and slash-command routing). Both forms reference the same agent. When parsing an incoming message that contains both, treat them as references to ONE entity, not two. Never split yourself into multiple addressees based on surface form. Never assign yourself to multiple roles in a single turn. The authoritative bindings come from the runtime identity preamble (`ASSISTANT_NAME` / `ASSISTANT_USERNAME`); the rule applies to whatever pair of strings that preamble names.
 
 ## Async Tasks
 

--- a/rules/progress-updates.md
+++ b/rules/progress-updates.md
@@ -24,7 +24,7 @@ When launching a background agent for a task that may take more than 30 seconds,
 ## Rules
 
 - The initial emoji reaction remains the first acknowledgement — progress updates come AFTER, only if work is lengthy.
-- One update is usually enough. Two max for very long tasks. Don't spam.
+- One update is usually enough. Two max for tasks beyond ~2 minutes. Don't spam.
 - Match the language of the original message.
 - If the task finishes quickly (<30s), no update needed — just deliver the result.
 - Progress updates use `send_message` with the same `reply_to` as the final result.

--- a/rules/read-full-content.md
+++ b/rules/read-full-content.md
@@ -16,10 +16,6 @@ Before drawing any conclusion from external content:
 
 For Gmail specifically: use `format: "full"`, decode `payload.parts[]` (find `mimeType: "text/plain"`, base64url-decode `body.data`). `messageText`, `preview`, and `snippet` fields are truncated — acceptable for **display only**, never for decisions.
 
-## Why
-
-Truncated previews optimize for speed at the cost of correctness. Re-doing work because of a wrong decision based on incomplete content is more expensive than reading fully once. There is no valid reason to use a preview when making a decision.
-
 ## Applies to
 
 - Task due date assignment from email links


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Three targeted cuts per `jbaruch/coding-policy: context-writing-style` "What to Cut":

- `core-behavior.md` — drop "just because both forms appear" because-clause attaching rationale to the dual-handle directive
- `progress-updates.md` — replace "very long tasks" with "tasks beyond ~2 minutes" (intensifier carrying no constraint → concrete bound)
- `read-full-content.md` — drop `## Why` section in full (3 lines of meta-justification)

## Scope

Documentation / rule-prose. Companion to the tier-1 conciseness PRs (`nanoclaw-host#22`, `nanoclaw-trusted#46`, `nanoclaw-admin#277`, `coding-policy#87` — all merged) and the in-flight tier-3 batch (`nanoclaw-host`, `nanoclaw-trusted`, `nanoclaw-untrusted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)