### PR TITLE
feat(rules): switch progress-updates to conditional applyTo (#552 core portion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules — `progress-updates` switched to conditional `applyTo:` (`jbaruch/nanoclaw#552`)
+
+The `progress-updates` rule's prescription only fires when spawning background agents or other long-running tasks (>30s expected) — keeping it always-on in baseline context paid the full body cost on every turn even when the agent had no background work to launch. Per `jbaruch/coding-policy: rule-frontmatter`, switched `alwaysApply: true` → `alwaysApply: false` + `applyTo: "** — when spawning background agents or other long-running tasks (>30s expected) that may need progress updates back to chat"`. The rule body is unchanged; only the frontmatter switched. Bundled with the same split-value drift fix from the trusted-tile portion: `tile.json` now sets explicit `"alwaysApply"` on every rule entry, closing the previously-implicit/rule-file-only state that `rule-frontmatter` warns against. The other 11 core rules (`core-behavior`, `telegram-protocol`, `language-matching`, `default-silence`, `temporal-awareness`, `ground-truth`, `read-full-content`, `context-recovery`, `post-compaction-trust`, `tone-matching`, `query-size-limits`) stay always-on by design — every one governs decision quality or chat hygiene on every turn. Parallel companion PR `jbaruch/nanoclaw-trusted#49` handles 9 task-context rules in the trusted tile.
+
 ### Rules — conciseness pass tier 3 per `coding-policy: context-writing-style`
 
 - **core-behavior** — drop "just because both forms appear" because-clause from the dual-handle section. Operative directive ("Never assign yourself to multiple roles in a single turn") stays; the rationale clause goes.

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ tessl install jbaruch/nanoclaw-core
 
 ## Rules
 
-| Rule | Summary |
-|------|---------|
-| [core-behavior](rules/core-behavior.md) | Baseline conversational behavior — concise replies, no trailing summaries |
-| [telegram-protocol](rules/telegram-protocol.md) | Telegram-channel formatting and reply conventions |
-| [language-matching](rules/language-matching.md) | Match the user's language; don't volunteer translations |
-| [default-silence](rules/default-silence.md) | Silent-on-no-news as the default; surface only what's actionable |
-| [temporal-awareness](rules/temporal-awareness.md) | Convert relative dates, respect timezones, never schedule reminders for the past |
-| [ground-truth](rules/ground-truth.md) | Live source > cached/recalled state; always verify before acting |
-| [read-full-content](rules/read-full-content.md) | Read full email/message bodies, never just snippets/previews |
-| [context-recovery](rules/context-recovery.md) | Recover from compaction by reading state, not by claiming lost context. Includes post-compaction skill-block disambiguation (history vs new tasks) |
-| [post-compaction-trust](rules/post-compaction-trust.md) | Compaction summaries are trusted state; do not re-derive what's already there |
-| [tone-matching](rules/tone-matching.md) | Mirror the user's register; tone shifts signal mode shifts |
-| [query-size-limits](rules/query-size-limits.md) | Bounded SQL/API queries; never SELECT * on large tables |
-| [progress-updates](rules/progress-updates.md) | Brief updates at key moments; silence is not a failure |
+| Rule | Scope | Summary |
+|------|-------|---------|
+| [core-behavior](rules/core-behavior.md) | always-on | Baseline conversational behavior — concise replies, no trailing summaries |
+| [telegram-protocol](rules/telegram-protocol.md) | always-on | Telegram-channel formatting and reply conventions |
+| [language-matching](rules/language-matching.md) | always-on | Match the user's language; don't volunteer translations |
+| [default-silence](rules/default-silence.md) | always-on | Silent-on-no-news as the default; surface only what's actionable |
+| [temporal-awareness](rules/temporal-awareness.md) | always-on | Convert relative dates, respect timezones, never schedule reminders for the past |
+| [ground-truth](rules/ground-truth.md) | always-on | Live source > cached/recalled state; always verify before acting |
+| [read-full-content](rules/read-full-content.md) | always-on | Read full email/message bodies, never just snippets/previews |
+| [context-recovery](rules/context-recovery.md) | always-on | Recover from compaction by reading state, not by claiming lost context. Includes post-compaction skill-block disambiguation (history vs new tasks) |
+| [post-compaction-trust](rules/post-compaction-trust.md) | always-on | Compaction summaries are trusted state; do not re-derive what's already there |
+| [tone-matching](rules/tone-matching.md) | always-on | Mirror the user's register; tone shifts signal mode shifts |
+| [query-size-limits](rules/query-size-limits.md) | always-on | Bounded SQL/API queries; never SELECT * on large tables |
+| [progress-updates](rules/progress-updates.md) | conditional | Brief updates at key moments; silence is not a failure |
 
 ## Skills
 

--- a/rules/progress-updates.md
+++ b/rules/progress-updates.md
@@ -1,5 +1,6 @@
 ---
-alwaysApply: true
+alwaysApply: false
+applyTo: "** — when spawning background agents or other long-running tasks (>30s expected) that may need progress updates back to chat"
 ---
 
 # Progress Updates for Long Tasks

--- a/tile.json
+++ b/tile.json
@@ -6,40 +6,52 @@
   "private": false,
   "rules": {
     "core-behavior": {
-      "rules": "rules/core-behavior.md"
+      "rules": "rules/core-behavior.md",
+      "alwaysApply": true
     },
     "telegram-protocol": {
-      "rules": "rules/telegram-protocol.md"
+      "rules": "rules/telegram-protocol.md",
+      "alwaysApply": true
     },
     "language-matching": {
-      "rules": "rules/language-matching.md"
+      "rules": "rules/language-matching.md",
+      "alwaysApply": true
     },
     "default-silence": {
-      "rules": "rules/default-silence.md"
+      "rules": "rules/default-silence.md",
+      "alwaysApply": true
     },
     "temporal-awareness": {
-      "rules": "rules/temporal-awareness.md"
+      "rules": "rules/temporal-awareness.md",
+      "alwaysApply": true
     },
     "ground-truth": {
-      "rules": "rules/ground-truth.md"
+      "rules": "rules/ground-truth.md",
+      "alwaysApply": true
     },
     "read-full-content": {
-      "rules": "rules/read-full-content.md"
+      "rules": "rules/read-full-content.md",
+      "alwaysApply": true
     },
     "context-recovery": {
-      "rules": "rules/context-recovery.md"
+      "rules": "rules/context-recovery.md",
+      "alwaysApply": true
     },
     "post-compaction-trust": {
-      "rules": "rules/post-compaction-trust.md"
+      "rules": "rules/post-compaction-trust.md",
+      "alwaysApply": true
     },
     "tone-matching": {
-      "rules": "rules/tone-matching.md"
+      "rules": "rules/tone-matching.md",
+      "alwaysApply": true
     },
     "query-size-limits": {
-      "rules": "rules/query-size-limits.md"
+      "rules": "rules/query-size-limits.md",
+      "alwaysApply": true
     },
     "progress-updates": {
-      "rules": "rules/progress-updates.md"
+      "rules": "rules/progress-updates.md",
+      "alwaysApply": false
     }
   },
   "skills": {


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Implements the core-tile portion of `jbaruch/nanoclaw#552` (RULES.md baseline-token reduction).

The `progress-updates` rule's prescription only fires when spawning background agents or other long-running tasks (>30s expected) — keeping it always-on in baseline context paid the full body cost on every turn even when the agent had no background work to launch. Per `jbaruch/coding-policy: rule-frontmatter`, switched `alwaysApply: true` → `alwaysApply: false` + `applyTo: "** — when spawning background agents or other long-running tasks (>30s expected) that may need progress updates back to chat"`.

## Drift fix bundled in

`nanoclaw-core/tile.json` previously had no explicit `alwaysApply` on any rule entry — every rule was implicit-True via the rule-file frontmatter alone. This is the tile.json/rule-file split-value state that `rule-frontmatter` explicitly warns against ("split values are inconsistent and may produce surprising behavior"). This PR sets explicit `"alwaysApply": true` on the other 11 rule entries to close the drift, and explicit `false` on `progress-updates` to match its new conditional state.

## Kept always-on

The remaining 11 core rules govern decision quality or chat hygiene on every turn — lazy-loading risks regression:

- `core-behavior`, `telegram-protocol`, `language-matching`, `default-silence`, `temporal-awareness`, `ground-truth`, `read-full-content`, `context-recovery`, `post-compaction-trust`, `tone-matching`, `query-size-limits`

## Surface sync

- `tile.json` — explicit `alwaysApply` on every steering entry
- `README.md` — rules table gains a `Scope` column
- `CHANGELOG.md` — Unreleased entry describes the conversion + the drift fix

## Companion PR

`jbaruch/nanoclaw-trusted#49` handles the trusted-tile portion: 9 task-context rules. Together they cover 10 of the 11 conditional candidates listed in `#552` (the 11th, `cli-tools-not-installed`, doesn't exist by that name in any current tile — flagged in `#49`'s description for follow-up).

## Test plan

- [x] `python3 -m pytest tests/` — **17 passed**
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `progress-updates` frontmatter has both halves of the `applyTo:` contract (glob + natural-language clause)
- [x] Every tile.json rule entry's `alwaysApply` value matches the corresponding rule file's frontmatter

## Rule citations

- `jbaruch/coding-policy: rule-frontmatter` — conditional-rules contract, glob+clause syntax, tile.json/rule-file consistency
- `jbaruch/coding-policy: context-artifacts` — surface-sync requirements
- `jbaruch/coding-policy: boy-scout` — drift fix on adjacent tile.json entries rolled into the in-scope PR