### PR TITLE
chore(ci): gate language diagnostics with pyright

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Keep the dev toolchain (pyright, ruff, pytest) on the latest release
+  # without giving up reproducibility: deps stay hard-pinned in
+  # requirements-dev.txt, and Dependabot opens a PR for each new version so
+  # the bump is reviewed and CI proves it green before it lands — rather
+  # than a floating spec that can break CI on an unrelated PR.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(deps)
+    labels:
+      - dependencies
+  # Keep the Actions used by the test workflow current on the same terms.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)
+    labels:
+      - dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,11 @@ jobs:
           python -m ruff check tests/
           python -m ruff format --check tests/
 
+      # Diagnostics gate per `jbaruch/coding-policy: language-diagnostics`
+      # — runs pyright at zero findings before tests, resolving the
+      # skill-bundle sys.path layout via pyrightconfig.json.
+      - name: Type check (pyright)
+        run: python -m pyright skills/ tests/
+
       - name: Pytest
         run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,10 @@ jobs:
 
       # Diagnostics gate per `jbaruch/coding-policy: language-diagnostics`
       # — runs pyright at zero findings before tests, resolving the
-      # skill-bundle sys.path layout via pyrightconfig.json.
+      # skill-bundle sys.path layout via pyrightconfig.json. `--warnings`
+      # makes warnings (not just errors) fail the step's exit code.
       - name: Type check (pyright)
-        run: python -m pyright skills/ tests/
+        run: python -m pyright --warnings skills/ tests/
 
       - name: Pytest
         run: python -m pytest

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "executionEnvironments": [
+    { "root": "skills/now-vs-deadline", "extraPaths": ["skills/now-vs-deadline"] },
+    { "root": "skills/query-history", "extraPaths": ["skills/query-history"] },
+    { "root": "skills/status", "extraPaths": ["skills/status"] },
+    { "root": "tests", "extraPaths": ["skills/now-vs-deadline", "skills/query-history", "skills/status"] }
+  ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+pyright==1.1.408
 pytest==8.3.4
 ruff==0.7.4

--- a/tests/test_query_message_history.py
+++ b/tests/test_query_message_history.py
@@ -20,6 +20,8 @@ import json
 import sqlite3
 from contextlib import redirect_stderr, redirect_stdout
 
+import pytest
+
 
 def _populate_db(path: str) -> None:
     """Build a tiny fixed dataset deterministically.
@@ -64,7 +66,13 @@ def _populate_db(path: str) -> None:
     conn.close()
 
 
-def _run(module, argv, monkeypatch, db_path=None, chat_jid="chatA"):
+def _run(
+    module,
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    db_path: str | None = None,
+    chat_jid: str | None = "chatA",
+) -> tuple[int, dict | None, str]:
     """Invoke `main(argv)` with env vars set, capturing stdout/stderr.
 
     Returns (exit_code, parsed_stdout_payload_or_None, stderr_text).
@@ -84,6 +92,14 @@ def _run(module, argv, monkeypatch, db_path=None, chat_jid="chatA"):
     stdout = out.getvalue()
     payload = json.loads(stdout) if stdout.strip() else None
     return rc, payload, err.getvalue()
+
+
+def _require_payload(payload: dict | None) -> dict:
+    """Narrow a `_run` payload to a present dict for tests on the success
+    and canonical-error paths, which always print a JSON payload. Usage-error
+    paths return None and must not call this."""
+    assert payload is not None, "expected a JSON payload but stdout was empty"
+    return payload
 
 
 def test_no_filters_is_usage_error(query_message_history, monkeypatch):
@@ -141,6 +157,7 @@ def test_missing_chat_jid_returns_canonical_error(query_message_history, monkeyp
     )
     assert rc == 1
     assert "NANOCLAW_CHAT_JID" in stderr
+    payload = _require_payload(payload)
     assert payload["rows"] == []
     assert payload["error"].startswith("NANOCLAW_CHAT_JID")
     assert payload["query"] == {"keyword": "release", "sender": None, "limit": 20}
@@ -156,6 +173,7 @@ def test_keyword_filter_returns_matching_rows_in_chat(query_message_history, mon
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     contents = [r["content"] for r in payload["rows"]]
     # Two chatA messages contain 'release plan'; chatB row is excluded.
     # Also excluded: 'replying to release' (different substring),
@@ -176,6 +194,7 @@ def test_sender_filter_uses_sender_name_substring(query_message_history, monkeyp
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     # Four chatA rows where sender_name LIKE '%alice%' (ids 1, 3, 6, 7).
     # The chatB alice row (id=4) is excluded by the chat_jid filter.
     senders = {r["sender_name"] for r in payload["rows"]}
@@ -193,6 +212,7 @@ def test_combined_filters_AND(query_message_history, monkeypatch, tmp_path):
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     # Alice has two release-plan-substring rows in chatA: id=1 ('release
     # plan for Q3') is the only one that matches 'release plan' AND
     # alice. id=2 is Bob.
@@ -216,6 +236,7 @@ def test_keyword_underscore_wildcard_is_escaped(query_message_history, monkeypat
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     ids = sorted(r["id"] for r in payload["rows"])
     assert ids == [6], (
         f"Expected only id=6 (literal `john_doe`), got {ids}. "
@@ -238,6 +259,7 @@ def test_keyword_percent_wildcard_is_escaped(query_message_history, monkeypatch,
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     assert payload["rows"] == [], (
         f"Expected empty result for literal `%doe` (no row contains it), "
         f"got {[r['id'] for r in payload['rows']]}. The `%` wildcard is "
@@ -255,6 +277,7 @@ def test_limit_caps_results(query_message_history, monkeypatch, tmp_path):
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     assert len(payload["rows"]) == 2
     assert payload["query"]["limit"] == 2
 
@@ -273,6 +296,7 @@ def test_db_missing_returns_canonical_error(query_message_history, monkeypatch, 
     )
     assert rc == 1
     assert "DB access failed" in stderr
+    payload = _require_payload(payload)
     assert payload["rows"] == []
     assert payload["error"].startswith("DB access failed")
 
@@ -287,6 +311,7 @@ def test_payload_shape_is_canonical_on_success(query_message_history, monkeypatc
         db_path=db_path,
     )
     assert rc == 0
+    payload = _require_payload(payload)
     assert set(payload.keys()) == {"rows", "chat_jid", "query", "error"}
     assert payload["chat_jid"] == "chatA"
     if payload["rows"]:

--- a/tests/test_query_message_history.py
+++ b/tests/test_query_message_history.py
@@ -98,7 +98,8 @@ def _require_payload(payload: dict | None) -> dict:
     """Narrow a `_run` payload to a present dict for tests on the success
     and canonical-error paths, which always print a JSON payload. Usage-error
     paths return None and must not call this."""
-    assert payload is not None, "expected a JSON payload but stdout was empty"
+    if payload is None:
+        raise AssertionError("expected a JSON payload but stdout was empty")
     return payload
 
 


### PR DESCRIPTION
Adopts `jbaruch/coding-policy: language-diagnostics` in this repo: enables pyright and gates it in CI at zero findings, before tests, alongside the existing ruff step. Modeled on the worked config from `jbaruch/nanoclaw-travel#81`.

## What changed
- **`pyrightconfig.json`** — per-bundle `executionEnvironments`, one root per skill dir (`now-vs-deadline`, `query-history`, `status`) plus a `tests` root whose `extraPaths` lists every skill dir. The skill bundles ship kebab-case scripts loaded by file location, so each bundle resolves under its own root rather than one flat path.
- **`requirements-dev.txt`** — pin `pyright==1.1.408` (kept sorted with the existing ruff/pytest pins).
- **`.github/workflows/test.yml`** — new `Type check (pyright)` step running `python -m pyright skills/ tests/`, placed after `Lint (ruff)` and before `Pytest`.
- **`.github/dependabot.yml`** — boy-scout addition (see below).

## Real bugs pyright surfaced
The first-ever run surfaced **24 findings, all in `tests/test_query_message_history.py`** — no source bugs in `skills/`. Two shapes, both fixed properly (no suppressions):

- **`reportArgumentType` (1)** — the `_run` helper defaulted `db_path`/`chat_jid` to values that made pyright infer `str`, so `test_missing_chat_jid_returns_canonical_error` passing `chat_jid=None` was a type error even though the helper body explicitly handles `None`. **Fix:** annotate the params `str | None` and give `_run` an explicit `tuple[int, dict | None, str]` return type.
- **`reportOptionalSubscript` / `reportOptionalMemberAccess` (23)** — `payload` is `dict | None` (`json.loads(...) if stdout else None`), and the success/canonical-error tests subscript `payload[...]` after asserting the run produced output. **Fix:** a typed assert-not-None reader `_require_payload(payload: dict | None) -> dict` that narrows at point of access on the paths that always emit JSON. Usage-error tests (which assert `payload is None`) keep calling `_run` directly.

No blanket `# type: ignore`, `# pyright: basic`, or file-wide suppression anywhere.

## Third-party import resolution
None needed — all three skill scripts are stdlib-only (`argparse`, `datetime`, `json`, `os`, `sqlite3`, `sys`, `typing`) and none import each other, so there were no unresolved third-party imports to resolve. No CI install changes beyond the pyright pin.

## Boy-scout: Dependabot
The repo had no `.github/dependabot.yml`, so the existing ruff/pytest pins had no stated renewal mechanism either. Added a weekly Dependabot covering the `pip` (requirements-dev.txt) and `github-actions` ecosystems — this satisfies dependency-management's "every pin needs a stated renewal mechanism" for the new pyright pin and cleans up the pre-existing gap for ruff/pytest in one go.

## Verification (local, all green)
- `python -m ruff check tests/` and `python -m ruff format --check tests/` — clean (ruff scope unchanged)
- `python -m pyright skills/ tests/` — 0 errors, 0 warnings, 0 informations
- `python -m pytest` — 31 passed

Closes #53

**Author-Model:** claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)