### PR TITLE
ci: wire coding-policy stamp-changelog step before publish

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Lint tile
         run: tessl tile lint .
 
+      # Stamps the top un-headed `### ` CHANGELOG blocks with the
+      # `## <version> — <date>` heading the publish step is about to assign,
+      # per jbaruch/coding-policy: context-artifacts "CHANGELOG Hygiene".
+      # Must run immediately before patch-version-publish.
+      - name: Stamp CHANGELOG
+        uses: jbaruch/coding-policy/.github/actions/stamp-changelog@de18c1b923ed55afed7fb4c96efe35926c0e7bbf # main
+
       - uses: tesslio/patch-version-publish@v1
         with:
           token: ${{ secrets.TESSL_TOKEN }}


### PR DESCRIPTION
Wires the `jbaruch/coding-policy` **stamp-changelog** action into the publish workflow, immediately before `tesslio/patch-version-publish` — matching `nanoclaw-travel`, which already has it.

**Scope: CI configuration only** (`.github/workflows/publish-tile.yml`). No source, skill, or rule change.

With the step wired, a PR author drops an un-headed `### ` block at the top of `CHANGELOG.md` and the step stamps the `## <version> — <date>` heading at publish time. This is what stops released versions from drifting out of the CHANGELOG (the drift that required the recent backfill). The action is pinned to the same SHA `nanoclaw-travel` uses; the github-actions Dependabot added earlier keeps it fresh.

First run is a safe no-op — the CHANGELOG currently has no un-headed blocks.

**Author-Model:** claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)