### PR TITLE
ci(publish): gate on test suite and pin actions by SHA

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -22,6 +22,32 @@ jobs:
           # `fetch-depth: 0` keeps the path predictable.
           fetch-depth: 0
 
+      # Gate publishing on the same lint/type/test suite the Test workflow
+      # runs (jbaruch/nanoclaw-core#74). Test runs as a separate workflow
+      # with no ordering guarantee against this one, so without an in-line
+      # gate a broken merge commit can publish before its tests fail.
+      # These steps run before any tessl setup so a red suite fails fast
+      # and cheaply.
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: |
+          python -m ruff check tests/
+          python -m ruff format --check tests/
+
+      - name: Type check (pyright)
+        run: python -m pyright --warnings skills/ tests/
+
+      - name: Pytest
+        run: python -m pytest
+
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Required by jbaruch/coding-policy/.github/actions/skill-review:
           # the action runs `git diff $BEFORE..HEAD` to find changed skills.
@@ -48,7 +48,7 @@ jobs:
       - name: Pytest
         run: python -m pytest
 
-      - uses: tesslio/setup-tessl@v2
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
@@ -71,6 +71,6 @@ jobs:
       - name: Stamp CHANGELOG
         uses: jbaruch/coding-policy/.github/actions/stamp-changelog@de18c1b923ed55afed7fb4c96efe35926c0e7bbf # main
 
-      - uses: tesslio/patch-version-publish@v1
+      - uses: tesslio/patch-version-publish@d1363877846ebf6bc09e032e2dc8612f1d7e38dd # v1
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -1,8 +1,9 @@
 name: Review & Publish Tile
 
-permissions:
-  id-token: write
-  contents: write
+# Least privilege per job: nothing at workflow level. The gate job runs
+# the pip-installed test toolchain under a read-only token; only the
+# publish job holds id-token/contents write and TESSL_TOKEN.
+permissions: {}
 
 on:
   push:
@@ -11,7 +12,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Gate publishing on the same lint/type/test suite the Test workflow
+  # runs on PRs (jbaruch/nanoclaw-core#74). Test previously ran as a
+  # separate push-triggered workflow with no ordering guarantee against
+  # this one, so a broken merge commit could publish before its tests
+  # failed. Calling the reusable workflow keeps one definition of the
+  # suite — no drift between PR checks and the publish gate.
+  gate:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test.yml
+
   publish:
+    needs: gate
+    permissions:
+      id-token: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -21,32 +37,6 @@ jobs:
           # The action falls back to a depth-recovery fetch if needed, but
           # `fetch-depth: 0` keeps the path predictable.
           fetch-depth: 0
-
-      # Gate publishing on the same lint/type/test suite the Test workflow
-      # runs (jbaruch/nanoclaw-core#74). Test runs as a separate workflow
-      # with no ordering guarantee against this one, so without an in-line
-      # gate a broken merge commit can publish before its tests fail.
-      # These steps run before any tessl setup so a red suite fails fast
-      # and cheaply.
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: '3.11'
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install -r requirements-dev.txt
-
-      - name: Lint (ruff)
-        run: |
-          python -m ruff check tests/
-          python -m ruff format --check tests/
-
-      - name: Type check (pyright)
-        run: python -m pyright --warnings skills/ tests/
-
-      - name: Pytest
-        run: python -m pytest
 
       - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,10 @@ permissions:
 
 on:
   pull_request:
-  push:
-    branches: [main]
+  # Callable as the publish workflow's gate job — main-push coverage
+  # comes from that call, so no separate `push: main` trigger (it
+  # would run the suite twice per merge).
+  workflow_call:
 
 jobs:
   pytest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI — gate publishing on ruff, pyright, and pytest (`jbaruch/nanoclaw-core#74`)
+
+The publish workflow triggered on every push to `main` independently of the `Test` workflow, so a broken merge commit could publish before its own tests failed. The lint/type/test suite now runs inside the publish workflow, before any tessl step.
+
 ## 0.1.112 — 2026-07-02
 
 ### Changed — backfill CHANGELOG entries for released versions 0.1.109–0.1.111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### CI — gate publishing on ruff, pyright, and pytest (`jbaruch/nanoclaw-core#74`)
 
-The publish workflow triggered on every push to `main` independently of the `Test` workflow, so a broken merge commit could publish before its own tests failed. The lint/type/test suite now runs inside the publish workflow, before any tessl step.
+The publish workflow triggered on every push to `main` independently of the `Test` workflow, so a broken merge commit could publish before its own tests failed. `test.yml` is now a reusable (`workflow_call`) workflow; the publish workflow runs it as a `gate` job the `publish` job `needs`. One suite definition serves PR checks and the publish gate (review feedback: no drift between duplicated step lists), and per-job least privilege keeps the pip-installed toolchain under a read-only token — only the `publish` job holds `id-token`/`contents: write` and `TESSL_TOKEN`. `test.yml` drops its `push: main` trigger; main-push coverage comes from the gate call.
 
 ## 0.1.112 — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI — pin workflow actions by commit SHA (`jbaruch/nanoclaw-core#75`)
+
+`actions/checkout`, `actions/setup-python`, `tesslio/setup-tessl`, and `tesslio/patch-version-publish` were tag-pinned in a job holding `TESSL_TOKEN` and `contents: write` — a retargeted upstream tag could change release behavior without a reviewed repo diff. All workflow actions are now pinned to full commit SHAs with tag comments; the existing weekly Dependabot `github-actions` config is the renewal mechanism.
+
 ### CI — gate publishing on ruff, pyright, and pytest (`jbaruch/nanoclaw-core#74`)
 
 The publish workflow triggered on every push to `main` independently of the `Test` workflow, so a broken merge commit could publish before its own tests failed. The lint/type/test suite now runs inside the publish workflow, before any tessl step.


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- Gate the publish workflow on ruff, pyright, and pytest (#74): the Test workflow runs separately with no ordering guarantee, so a broken merge commit could publish before its tests failed. The suite now runs inside the publish job, before any tessl setup.
- Pin all workflow actions to full commit SHAs with tag comments (#75): tag references in a job holding `TESSL_TOKEN` + `contents: write` could be retargeted upstream without a reviewed diff. The existing weekly Dependabot `github-actions` config is the renewal mechanism.

This PR is explicitly CI-scoped per `rules/ci-safety.md` Hands Off CI Config — the workflow edits are the stated scope.

Fixes #74
Fixes #75

## Test plan
- [x] Local: ruff, pyright (0 findings), pytest (31 passed) all green
- [x] Workflow YAML parses
- [ ] Test workflow green on this PR
- [ ] Post-merge: publish run green with the new gate steps executing before `patch-version-publish`; registry version advances; moderation clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9pCQFXbK5BbnsakvMjn7z