### PR TITLE
docs: refresh stale repo docs, fix helper path, backfill changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,11 +13,13 @@
 ```
 tile.json                    # Tile manifest: name, version, rules/skills registry
 README.md                    # Human-readable overview + rules/skills tables
-CHANGELOG.md                 # Version history and unreleased changes
+CHANGELOG.md                 # Version history; un-headed `### ` blocks at the top
+                             # are stamped with the version heading at publish
 pyproject.toml               # pytest config + ruff lint (scoped to tests/ only)
-requirements-dev.txt         # Dev dependencies: pytest==8.3.4, ruff==0.7.4
+pyrightconfig.json           # pyright module resolution for the skill-bundle layout
+requirements-dev.txt         # Dev dependencies: pyright, pytest, ruff (pinned)
 
-rules/                       # 12 always-on behavioral rule files (Markdown)
+rules/                       # 12 behavioral rule files (11 always-on, 1 conditional)
   core-behavior.md
   telegram-protocol.md
   default-silence.md
@@ -53,10 +55,12 @@ tests/
 
 .github/
   workflows/
-    test.yml                # CI: ruff lint + pytest on every PR and push to main
-    publish-tile.yml        # Publish tile to tessl registry on push to main
-    review-openai.yml/.md   # AI-assisted PR review (OpenAI)
-    review-anthropic.yml/.md# AI-assisted PR review (Anthropic)
+    test.yml                # CI: ruff + pyright + pytest on every PR; callable
+                            # (workflow_call) as the publish workflow's gate job
+    publish-tile.yml        # On push to main: test-suite gate, skill review,
+                            # tile lint, CHANGELOG stamp, publish to tessl registry
+    review-openai.md        # AI-assisted PR review (OpenAI; compiled .lock.yml)
+    review-anthropic.md     # AI-assisted PR review (Anthropic; compiled .lock.yml)
 ```
 
 ---
@@ -76,13 +80,19 @@ python -m ruff check tests/
 python -m ruff format --check tests/
 ```
 
+**Type check** (zero-findings gate; `--warnings` fails on warnings too; module resolution via `pyrightconfig.json`):
+
+```bash
+python -m pyright --warnings skills/ tests/
+```
+
 **Run tests:**
 
 ```bash
 python -m pytest
 ```
 
-CI runs these in order: ruff check → ruff format → pytest. All three must pass on every PR.
+CI runs these in order: ruff check → ruff format → pyright → pytest. All four must pass on every PR.
 
 **There is no build step.** This is a pure Python + Markdown tile; nothing needs compiling.
 
@@ -92,12 +102,13 @@ CI runs these in order: ruff check → ruff format → pytest. All three must pa
 
 ### Rule files (`rules/*.md`)
 
-- Every rule file **must** have YAML frontmatter with `alwaysApply: true` as the first thing in the file:
+- Every rule file **must** open with YAML frontmatter declaring its scope. Always-on rules (the default here — 11 of 12) use:
   ```markdown
   ---
   alwaysApply: true
   ---
   ```
+- Conditional rules use `alwaysApply: false` plus an `applyTo:` glob+prose scope (see `rules/progress-updates.md` for the live example). Both forms are valid tessl frontmatter; pick by whether the rule's prescription fires on every turn or only in a specific context.
 - One concern per rule file — keep rules focused so consumers can override surgically.
 - Rule filenames are kebab-case (e.g., `core-behavior.md`).
 
@@ -132,11 +143,11 @@ CI runs these in order: ruff check → ruff format → pytest. All three must pa
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `test.yml` | PR + push to `main` | Lint (`ruff`) + `pytest` |
-| `publish-tile.yml` | push to `main`, `workflow_dispatch` | tessl skill review (quality gate ≥85) + tile publish |
+| `test.yml` | PR + `workflow_call` | Lint (`ruff`) + type check (`pyright`) + `pytest` |
+| `publish-tile.yml` | push to `main`, `workflow_dispatch` | gate (calls `test.yml`) → tessl skill review (quality gate ≥85) → tile lint → CHANGELOG stamp → publish |
 | `review-openai.md` / `review-anthropic.md` | PR events | AI-assisted code review |
 
-The publish workflow runs `tessl skill review --threshold 85` on each skill before publishing. A failing quality score blocks the publish.
+The publish workflow first runs the full test suite as a read-only `gate` job (calling `test.yml` via `workflow_call` — main-push coverage comes from this call, not a separate `push:` trigger on `test.yml`), then `tessl skill review --threshold 85` on each changed skill. A red suite or failing quality score blocks the publish.
 
 ---
 
@@ -144,8 +155,8 @@ The publish workflow runs `tessl skill review --threshold 85` on each skill befo
 
 1. **`tile.json` + `README.md` drift** — if you add/remove a rule or skill in one place, update both. The table and the JSON registry must match.
 2. **Ruff scope** — ruff is intentionally limited to `tests/`. Do not widen it to `skills/*/scripts/` without an explicit decision in the PR.
-3. **Frontmatter required** — rule files without `alwaysApply: true` frontmatter will not be applied by the tessl runtime. Always include it.
+3. **Frontmatter required** — rule files without scope frontmatter will not be applied by the tessl runtime. Always include either `alwaysApply: true` or `alwaysApply: false` + `applyTo:` (conditional).
 4. **Kebab script loading** — if you add a new skill script and need to test it, add a fixture to `conftest.py` following the `_load()` pattern. Do not try to import the script directly.
 5. **Uniform JSON payload shape** — any new skill script that outputs JSON must guarantee all documented keys are present on every code path, including error paths.
-6. **Version bump** — increment `tile.json` version for any change intended to be published. The publish workflow does not auto-bump it.
-7. **CHANGELOG.md** — document unreleased changes under `## Unreleased` before they land in a release section.
+6. **Version bump** — the publish workflow auto-bumps the patch version via `tesslio/patch-version-publish` on every merge to `main`. Only edit `tile.json`'s version by hand for a minor or major bump.
+7. **CHANGELOG.md** — no `## Unreleased` heading. Add un-headed `### ` entry blocks at the top; the publish workflow's stamp step writes the `## <version> — <date>` heading at publish time. Every merge publishes a version, so every PR should carry an entry block.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,7 +122,7 @@ CI runs these in order: ruff check → ruff format → pyright → pytest. All f
 
 - Whenever a rule is added or removed, update both `tile.json` (the `rules` object) and the rules table in `README.md`.
 - Whenever a skill is added or removed, update both `tile.json` (the `skills` object) and the skills table in `README.md`.
-- The `version` field in `tile.json` follows semver; bump it for every change published to the tessl registry.
+- The `version` field in `tile.json` follows semver. The publish workflow bumps the patch version automatically on every merge to `main`; edit it by hand only for an intentional minor or major release (see gotcha 6).
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Docs — refresh contributor/agent docs for conditional rules, pyright, and publish behavior (`jbaruch/nanoclaw-core#76`, `jbaruch/nanoclaw-core#69`, `jbaruch/nanoclaw-core#71`)
+
+`.github/copilot-instructions.md` and the README philosophy section predated three repo changes and actively contradicted them: `progress-updates` is conditional (`alwaysApply: false` + `applyTo:`) while both docs demanded `alwaysApply: true` on every rule; the pyright CI gate (0.1.111) was absent from the lint/test instructions and CI table; and the publish flow docs still instructed manual version bumps and a `## Unreleased` heading, fighting the stamp-and-publish pipeline (0.1.113). All three are corrected. `rules/context-recovery.md` now shows the installed-container mount path as the runnable helper command instead of the repo-relative path that fails inside consumer containers (#69). Backfilled release headings for 0.1.113–0.1.115 below (#71) — reconstructed from the merge commits, including the release that added the stamp step and then shipped unstamped.
+
 ## 0.1.117 — 2026-07-07
 
 ### Skills — document the sub-second `delta_seconds` contract in now-vs-deadline (`jbaruch/nanoclaw-core#72`)
@@ -15,6 +19,24 @@ The output contract documented `delta_seconds` as signed (>0 future, <0 past), b
 ### CI — gate publishing on ruff, pyright, and pytest (`jbaruch/nanoclaw-core#74`)
 
 The publish workflow triggered on every push to `main` independently of the `Test` workflow, so a broken merge commit could publish before its own tests failed. `test.yml` is now a reusable (`workflow_call`) workflow; the publish workflow runs it as a `gate` job the `publish` job `needs`. One suite definition serves PR checks and the publish gate (review feedback: no drift between duplicated step lists), and per-job least privilege keeps the pip-installed toolchain under a read-only token — only the `publish` job holds `id-token`/`contents: write` and `TESSL_TOKEN`. `test.yml` drops its `push: main` trigger; main-push coverage comes from the gate call.
+
+## 0.1.115 — 2026-07-07
+
+### Changed — ignore tessl consumer-side scaffolding (`jbaruch/nanoclaw-core#67`)
+
+Backfilled entry (shipped without one): adds `.gitignore` coverage for tessl consumer-side scaffolding files so `tessl install` artifacts in a checkout don't show as untracked noise.
+
+## 0.1.114 — 2026-07-03
+
+### Changed — refresh coding-policy PR review workflows
+
+Backfilled entry (shipped without one): upgrade the gh-aw `jbaruch/coding-policy` PR review workflow templates (OpenAI + Anthropic) to the latest published version.
+
+## 0.1.113 — 2026-07-02
+
+### CI — wire coding-policy stamp-changelog step before publish (`jbaruch/nanoclaw-core#66`)
+
+Backfilled entry (shipped without one): adds the `jbaruch/coding-policy` stamp-changelog action immediately before `tesslio/patch-version-publish`. Authors add un-headed `### ` CHANGELOG blocks; the step writes the `## <version> — <date>` heading at publish time.
 
 ## 0.1.112 — 2026-07-02
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ tessl install jbaruch/nanoclaw-core
 
 ## Philosophy
 
-- **Always on.** Every rule is `alwaysApply: true`. The agent follows these conventions without being prompted.
+- **Always on by default.** 11 of the 12 rules are `alwaysApply: true` — the agent follows them without being prompted. `progress-updates` is conditional (`alwaysApply: false` + `applyTo:`), firing only when long-running background work is in play.
 - **One concern per rule.** Each file covers one topic so projects can override surgically without throwing out the whole tile.
 - **Behavior, not domain.** These are conversational and verification baselines — anything domain-specific (CFPs, calendar, email) lives in `nanoclaw-admin`.
 - **Hint, not authority for state.** Cached state is a recall hint; verify against the live source before acting on it (see `ground-truth`).

--- a/rules/context-recovery.md
+++ b/rules/context-recovery.md
@@ -13,10 +13,10 @@ alwaysApply: true
 Before responding with "Потерял контекст", "I don't remember this thread", "I don't have context on this topic", or any equivalent acknowledgement that prior conversation is unavailable, run the `query-history` skill's search helper:
 
 ```bash
-python3 skills/query-history/scripts/query-message-history.py --keyword "<text>"
+python3 /home/node/.claude/skills/tessl__query-history/scripts/query-message-history.py --keyword "<text>"
 ```
 
-Filters: `--sender <name>` (matches `sender_name`; see the Schema section below for the `Display (@username)` shape — a username fragment is enough), `--limit N` (default 20, cap 50 per `rules/query-size-limits.md`). Output is single-line JSON on stdout; chat scope from `NANOCLAW_CHAT_JID`. Inside agent containers the script mounts at `/home/node/.claude/skills/tessl__query-history/scripts/query-message-history.py` per the standard `tessl__<name>` convention.
+Filters: `--sender <name>` (matches `sender_name`; see the Schema section below for the `Display (@username)` shape — a username fragment is enough), `--limit N` (default 20, cap 50 per `rules/query-size-limits.md`). Output is single-line JSON on stdout; chat scope from `NANOCLAW_CHAT_JID`. The command above is the installed-container mount path (standard `tessl__<name>` convention); in a checkout of this repo the same script is `skills/query-history/scripts/query-message-history.py`.
 
 ## Schema (quick reference)
 


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- **#76 — docs refresh:** `copilot-instructions.md` and the README philosophy section contradicted the tree: `progress-updates` is conditional while both docs demanded `alwaysApply: true` everywhere; the pyright gate was missing from lint/test instructions and the CI table; the publish-flow notes prescribed manual version bumps and an `## Unreleased` heading against the stamp-and-publish pipeline. All aligned with current reality, including the gate-job publish shape from #77.
- **#69 — context-recovery path:** the runnable code block showed the repo-relative script path, which fails inside consumer containers; it now shows the `tessl__query-history` mount path with the repo-dev path noted in prose.
- **#71 — changelog backfill:** release headings for 0.1.113–0.1.115, reconstructed from merge commits. (0.1.113 is the release that added the stamp step — and shipped unstamped.)

Fixes #76
Fixes #69
Fixes #71

## Test plan
- [x] Suite green locally (31 passed); docs-only changes
- [ ] CI green; post-merge publish verified per release contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9pCQFXbK5BbnsakvMjn7z