### PR TITLE
ci(dependabot): ignore lock-file-only actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,15 @@ updates:
       prefix: chore(ci)
     labels:
       - dependencies
+    # Actions that appear ONLY inside the gh-aw-compiled
+    # `.github/workflows/*.lock.yml` files are owned by the `gh aw compile`
+    # step, not hand-authored here. Their `.gitattributes` `merge=ours`
+    # marking makes a Dependabot bump a no-op release, and the next
+    # reviewer-template upgrade recompile reverts it anyway (see closed
+    # PRs #57-#59). They refresh via the `tessl__install-reviewer` upgrade
+    # flow instead. `actions/checkout` and `actions/setup-python` are NOT
+    # ignored — those are hand-authored in test.yml/publish-tile.yml and
+    # stay Dependabot-managed (see #60, #61).
+    ignore:
+      - dependency-name: actions/cache*
+      - dependency-name: github/gh-aw-actions/setup

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
     # flow instead. `actions/checkout` and `actions/setup-python` are NOT
     # ignored — those are hand-authored in test.yml/publish-tile.yml and
     # stay Dependabot-managed (see #60, #61).
+    # Exact dependency names (not a wildcard) — Dependabot's github-actions
+    # ecosystem names each sub-action by its full path, and wildcard
+    # matching on nested paths is unreliable.
     ignore:
-      - dependency-name: actions/cache*
+      - dependency-name: actions/cache/save
+      - dependency-name: actions/cache/restore
       - dependency-name: github/gh-aw-actions/setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-### CI — stop Dependabot from opening lock-file-only action PRs (`jbaruch/nanoclaw-core#68` follow-up)
+### CI — stop Dependabot from opening lock-file-only action PRs (`jbaruch/nanoclaw-core#75` follow-up)
 
-The SHA-pinning work (#75) woke Dependabot, which then opened PRs bumping actions that live only in the gh-aw-compiled `.github/workflows/*.lock.yml` files (closed #57-#59). Those files carry `merge=ours` in `.gitattributes`, so a bump merges as a no-op and the next reviewer-template recompile reverts it. Added an `ignore` block for `actions/cache*` and `github/gh-aw-actions/setup`; hand-authored `actions/checkout` and `actions/setup-python` stay managed.
+The SHA-pinning work (#75) woke Dependabot, which then opened PRs bumping actions that live only in the gh-aw-compiled `.github/workflows/*.lock.yml` files (closed #57-#59). Those files carry `merge=ours` in `.gitattributes`, so a bump merges as a no-op and the next reviewer-template recompile reverts it. Added an `ignore` block naming `actions/cache/save`, `actions/cache/restore`, and `github/gh-aw-actions/setup` by exact dependency name; hand-authored `actions/checkout` and `actions/setup-python` stay managed.
 
 ## 0.1.125 — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The SHA-pinning work (#75) woke Dependabot, which then opened PRs bumping action
 ### CI — bump ruff to 0.15.20 (Dependabot, `jbaruch/nanoclaw-core#62`)
 
 Dev-toolchain pin refresh via the weekly Dependabot `pip` config: `ruff` 0.7.4 → 0.15.20 in `requirements-dev.txt`. `ruff check` and `ruff format --check` both pass clean on `tests/` at the new version — no formatting drift to reconcile.
+
 ## 0.1.124 — 2026-07-08
 
 ### CI — bump pytest to 9.1.1 (Dependabot, `jbaruch/nanoclaw-core#63`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+### CI — stop Dependabot from opening lock-file-only action PRs (`jbaruch/nanoclaw-core#68` follow-up)
+
+The SHA-pinning work (#75) woke Dependabot, which then opened PRs bumping actions that live only in the gh-aw-compiled `.github/workflows/*.lock.yml` files (closed #57-#59). Those files carry `merge=ours` in `.gitattributes`, so a bump merges as a no-op and the next reviewer-template recompile reverts it. Added an `ignore` block for `actions/cache*` and `github/gh-aw-actions/setup`; hand-authored `actions/checkout` and `actions/setup-python` stay managed.
+
 ## 0.1.125 — 2026-07-08
 
 ### CI — bump ruff to 0.15.20 (Dependabot, `jbaruch/nanoclaw-core#62`)
 
 Dev-toolchain pin refresh via the weekly Dependabot `pip` config: `ruff` 0.7.4 → 0.15.20 in `requirements-dev.txt`. `ruff check` and `ruff format --check` both pass clean on `tests/` at the new version — no formatting drift to reconcile.
-
 ## 0.1.124 — 2026-07-08
 
 ### CI — bump pytest to 9.1.1 (Dependabot, `jbaruch/nanoclaw-core#63`)


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
CI-scoped config change (the workflow-config edit is the stated scope, per `rules/ci-safety.md`).

The SHA-pinning work (#75) woke Dependabot, which opened eight PRs. Five were legitimate action/toolchain bumps (#60–#64, all merged). Three (#57–#59) bumped actions that live **only** inside the gh-aw-compiled `.github/workflows/*.lock.yml` files — `actions/cache/save`, `actions/cache/restore`, `github/gh-aw-actions/setup`. Those files carry `merge=ours` in `.gitattributes`, so a Dependabot bump merges as a no-op release, and the next `tessl__install-reviewer` recompile reverts it regardless. Closed all three.

This adds an `ignore` block for `actions/cache*` and `github/gh-aw-actions/setup` so those no-op PRs stop regenerating weekly. `actions/checkout` and `actions/setup-python` are **not** ignored — they're hand-authored in `test.yml`/`publish-tile.yml` and stay Dependabot-managed.

Fixes #57
Fixes #58
Fixes #59

## Test plan
- [x] `dependabot.yml` parses as valid YAML
- [ ] CI green; post-merge publish verified per release contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9pCQFXbK5BbnsakvMjn7z